### PR TITLE
Fix post-update blackscreen: swallow font NRE, unbreak ModLoaderPatches

### DIFF
--- a/src/STS2Mobile/ModEntry.cs
+++ b/src/STS2Mobile/ModEntry.cs
@@ -64,6 +64,7 @@ public static class ModEntry
             ModelDbInitPatch.Apply(_harmony);
             PlatformPatches.Apply(_harmony);
             SettingsPatches.Apply(_harmony);
+            FontSubstitutionPatches.Apply(_harmony);
             UiScalePatches.Apply(_harmony);
             MobileLayoutPatches.Apply(_harmony);
             EventLayoutPatches.Apply(_harmony);

--- a/src/STS2Mobile/Patches/FontSubstitutionPatches.cs
+++ b/src/STS2Mobile/Patches/FontSubstitutionPatches.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes;
+
+namespace STS2Mobile.Patches;
+
+// Post-game-update workaround: the game's
+// MegaCrit.Sts2.Core.Localization.Fonts.FontControlUtils.ApplyLocaleFontSubstitution
+// started throwing NullReferenceException on mobile after a recent StS2
+// update. The exception propagates out of every MegaLabel/NMegaTextEdit
+// _Ready(), which leaves the entire UI uninitialized and produces the
+// "post-update blackscreen" symptom.
+//
+// We install a Harmony finalizer that swallows the exception. Labels
+// miss their locale-specific font override but fall back to the theme
+// default, so the menu renders with readable (if not pixel-perfect)
+// text and the game becomes playable again.
+public static class FontSubstitutionPatches
+{
+    private static bool _loggedFirstSwallow;
+
+    public static void Apply(Harmony harmony)
+    {
+        var sts2Asm = typeof(NGame).Assembly;
+        var fontUtilsType = sts2Asm.GetType(
+            "MegaCrit.Sts2.Core.Localization.Fonts.FontControlUtils"
+        );
+        if (fontUtilsType == null)
+        {
+            PatchHelper.Log("FontSubstitutionPatches: FontControlUtils type not found; skipping");
+            return;
+        }
+
+        var target = fontUtilsType.GetMethod(
+            "ApplyLocaleFontSubstitution",
+            BindingFlags.Public
+                | BindingFlags.NonPublic
+                | BindingFlags.Static
+                | BindingFlags.Instance
+        );
+        if (target == null)
+        {
+            PatchHelper.Log(
+                "FontSubstitutionPatches: ApplyLocaleFontSubstitution method not found; skipping"
+            );
+            return;
+        }
+
+        try
+        {
+            var finalizer = typeof(FontSubstitutionPatches).GetMethod(
+                nameof(ApplyLocaleFontSubstitutionFinalizer),
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            harmony.Patch(target, finalizer: new HarmonyMethod(finalizer));
+            PatchHelper.Log("Patched FontControlUtils.ApplyLocaleFontSubstitution (finalizer)");
+        }
+        catch (Exception ex)
+        {
+            PatchHelper.Log($"FontSubstitutionPatches: install failed: {ex.Message}");
+        }
+    }
+
+    // Harmony finalizer signature: returning null suppresses the original
+    // method's exception; returning a non-null Exception replaces it.
+    private static Exception ApplyLocaleFontSubstitutionFinalizer(Exception __exception)
+    {
+        if (__exception == null)
+            return null;
+
+        if (!_loggedFirstSwallow)
+        {
+            _loggedFirstSwallow = true;
+            PatchHelper.Log(
+                $"FontSubstitutionPatches: suppressed {__exception.GetType().Name} "
+                    + $"from ApplyLocaleFontSubstitution (\"{__exception.Message}\"); "
+                    + "further occurrences silenced"
+            );
+        }
+
+        return null;
+    }
+}

--- a/src/STS2Mobile/Patches/ModLoaderPatches.cs
+++ b/src/STS2Mobile/Patches/ModLoaderPatches.cs
@@ -51,15 +51,45 @@ public static class ModLoaderPatches
 
             initializedField.SetValue(null, true);
 
-            // Rebuild _loadedMods to include anything new
+            // Rebuild _loadedMods to include anything new. Resolve Mod.wasLoaded
+            // and ModManager.LoadedMods via reflection: MegaCrit renamed both
+            // post-update (to PascalCase or elsewhere) and we want the build
+            // to survive further renames.
+            const BindingFlags InstFlags =
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
             var modsField = typeof(ModManager).GetField("_mods", AllStatic);
             var loadedModsField = typeof(ModManager).GetField("_loadedMods", AllStatic);
-            var allMods = (List<Mod>)modsField.GetValue(null);
-            loadedModsField.SetValue(null, allMods.Where(m => m.wasLoaded).ToList());
+            var allMods = (System.Collections.IList)modsField.GetValue(null);
 
-            PatchHelper.Log(
-                $"[Mods] External scan complete. Total loaded: {ModManager.LoadedMods.Count}"
-            );
+            MemberInfo wasLoadedMember =
+                (MemberInfo)typeof(Mod).GetField("wasLoaded", InstFlags)
+                ?? typeof(Mod).GetField("WasLoaded", InstFlags)
+                ?? (MemberInfo)typeof(Mod).GetProperty("wasLoaded", InstFlags)
+                ?? typeof(Mod).GetProperty("WasLoaded", InstFlags);
+
+            if (wasLoadedMember == null)
+            {
+                PatchHelper.Log(
+                    "[Mods] Could not locate Mod.wasLoaded field/property; skipping filter."
+                );
+                return;
+            }
+
+            Func<object, bool> isLoaded = wasLoadedMember switch
+            {
+                FieldInfo fi => (m => (bool)fi.GetValue(m)),
+                PropertyInfo pi => (m => (bool)pi.GetValue(m)),
+                _ => (_ => false),
+            };
+
+            var filtered = new List<Mod>();
+            foreach (var mod in allMods)
+                if (isLoaded(mod))
+                    filtered.Add((Mod)mod);
+            loadedModsField.SetValue(null, filtered);
+
+            PatchHelper.Log($"[Mods] External scan complete. Total loaded: {filtered.Count}");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
After a recent Slay the Spire 2 update the Android launcher started blackscreening at startup. Two issues against the new game DLL:

1. MegaCrit.Sts2.Core.Localization.Fonts.FontControlUtils .ApplyLocaleFontSubstitution throws NullReferenceException on mobile, which propagates out of every MegaLabel / NMegaTextEdit _Ready() and leaves the UI uninitialized (hence the black screen). Install a Harmony finalizer that swallows the exception; labels fall back to the theme default font and the menu/game render again.

2. ModLoaderPatches.ExternalModScanPostfix referenced Mod.wasLoaded and ModManager.LoadedMods directly. MegaCrit renamed / reshuffled both in the update, causing the patch to fail at runtime. Resolve both members via reflection (field-or-property, either casing) so the patch survives further renames.

Tested on a Samsung device running the updated game: with the old STS2Mobile.dll the launcher blackscreens, with this change the menu loads, cloud save syncs, and a run can be played through to completion.

Made-with: Cursor

## Summary

- What changed:
- Why:
- Related issue/PR:

## Validation

- [ ] Build/check command run:
- [ ] Manual test steps and device(s):
- [ ] Logs attached:
- [ ] No unrelated behavior changes

## Review checklist

- [ ] Code changes are scoped to one purpose
- [ ] Error paths return useful diagnostics
- [ ] Any workaround behavior is documented
