### PR TITLE
feat(overhaul): add governance smoke CI check and require status gate

### DIFF
--- a/.github/workflows/overhaul-governance-ci.yml
+++ b/.github/workflows/overhaul-governance-ci.yml
@@ -1,0 +1,45 @@
+name: Overhaul Governance CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  governance-smoke:
+    name: Governance Smoke Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Verify governance docs exist
+        run: |
+          test -f MIGRATION_CHECKLIST.md || { echo "Missing MIGRATION_CHECKLIST.md"; exit 1; }
+          test -f OVERHAUL_ROADMAP.md || { echo "Missing OVERHAUL_ROADMAP.md"; exit 1; }
+          test -f OVERHAUL_STATUS.md || { echo "Missing OVERHAUL_STATUS.md"; exit 1; }
+          test -f CONTRIBUTING.md || { echo "Missing CONTRIBUTING.md"; exit 1; }
+
+      - name: Validate repository diff hygiene
+        run: |
+          git diff --check
+          python - <<'PY'
+          from pathlib import Path
+
+          critical = [
+              "MIGRATION_CHECKLIST.md",
+              "OVERHAUL_ROADMAP.md",
+              "OVERHAUL_STATUS.md",
+              "CONTRIBUTING.md",
+          ]
+
+          for name in critical:
+              path = Path(name)
+              text = path.read_text(encoding="utf-8", errors="replace")
+              if not text.strip():
+                  raise SystemExit(f"{name} is unexpectedly empty")
+
+          print("Governance smoke checks passed.")
+          PY

--- a/MIGRATION_CHECKLIST.md
+++ b/MIGRATION_CHECKLIST.md
@@ -15,7 +15,7 @@ This repo started as an independent copy of [Ekyso/StS2-Launcher](https://github
 
 - [x] Define branch naming conventions (suggested: `rewrite/<area>-<topic>`, `fix/<area>`, `chore/<topic>`)
 - [x] Protect `main` in GitHub settings (direct pushes disabled, PR-first workflow)
-- [ ] Add branch protection rules for required status checks once CI exists
+- [x] Add branch protection rules for required status checks once CI exists
 - [x] Keep a `compat/legacy` branch for rollback if needed
 
 ## 3) Contributor & PR Workflow (To Do)

--- a/OVERHAUL_ROADMAP.md
+++ b/OVERHAUL_ROADMAP.md
@@ -36,3 +36,8 @@ This roadmap tracks the ongoing rewrite and stabilization effort.
 - [x] Establish rollback strategy branch (`compat/legacy`)
 - [x] Publish release/changelog strategy and backport policy
 - [x] Document branch protection expectations and deployment safety steps
+
+## Phase 5 — CI bootstrap and merge safety
+
+- [x] Add required-status-check workflow for governance/documentation safety
+- [x] Wire branch protection to require a deterministic CI check context

--- a/OVERHAUL_STATUS.md
+++ b/OVERHAUL_STATUS.md
@@ -2,10 +2,10 @@
 
 This file tracks what we are actively working on in the overhaul branch.
 
-## Current Focus (Phase 4 Governance Completion)
-- Document enforced branch-protection expectations and merge safety
-- Track release/backport policy compliance for merged architecture changes
-- Keep rollback branch aligned with latest release baseline
+## Current Focus (Phase 5 CI Bootstrapping)
+- Add a minimal required status check workflow for PR merge safety
+- Align branch protection on `main` with the new CI context
+- Keep compatibility backlog visible while CI matures beyond governance checks
 - Keep monthly status checks visible and action-oriented
 
 ## High-Impact Reliability Backlog
@@ -18,8 +18,8 @@ This file tracks what we are actively working on in the overhaul branch.
 | P3 | Multiplayer | LAN beacon persistence and discovery stability | Reliability | Low |
 
 ## Open Follow-up Tasks
-- Add required status checks to `main` once CI is in place
 - Keep status issue cadence alive and close issue #2 on phase transition
+- Expand CI checks from governance-only to include build smoke targets when references are available
 - Complete remaining compatibility hardening and close remaining phase-2 backlog items
 
 ## Active Status Issue

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -33,7 +33,11 @@ gh api repos/SocialHummingbird/StS2-Launcher-Overhaul/branches/main/protection \
   --field required_pull_request_reviews='{\"required_approving_review_count\":1,"required_approving_review_count":1}'
 ```
 
-If CI is not yet available, set required status checks as a placeholder and switch them on when workflows are added.
+When CI is available, prefer required status checks:
+
+- `Governance Smoke Check` (job: `governance-smoke` in `.github/workflows/overhaul-governance-ci.yml`)
+
+If CI is not yet available, keep status-check enforcement off and switch it on when workflows are added.
 
 ## Rollback branch policy
 


### PR DESCRIPTION
## Scope
- Add a lightweight governance smoke check workflow that validates checklist/docs presence and repository hygiene on PRs to `main`.
- Mark Phase 5 items in roadmap/status/checklist as complete.
- Configure `main` branch protection to require the `Governance Smoke Check` status.

## Validation
- GitHub branch protection now requires the new status check context
- `git diff --check`
- Docs/overhaul files include required items for phase transition

## Notes
This is intentionally scoped to governance safety checks only. Runtime code remains unchanged.