### PR TITLE
feat(overhaul): add artifact-aware CI build smoke job

### DIFF
--- a/.github/workflows/overhaul-governance-ci.yml
+++ b/.github/workflows/overhaul-governance-ci.yml
@@ -43,3 +43,37 @@ jobs:
 
           print("Governance smoke checks passed.")
           PY
+
+  build-smoke:
+    name: Build Smoke Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Check for project prerequisites
+        id: prerequisites
+        shell: bash
+        run: |
+          if [[ -f "upstream/godot-export/.godot/mono/publish/arm64/0Harmony.dll" \
+              && -f "upstream/godot-export/.godot/mono/publish/arm64/GodotSharp.dll" \
+              && -f "upstream/godot-export/.godot/mono/publish/arm64/sts2.dll" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run build smoke test
+        if: steps.prerequisites.outputs.available == 'true'
+        run: dotnet build src/STS2Mobile/STS2Mobile.csproj
+
+      - name: Skip build when publishing artifacts are unavailable
+        if: steps.prerequisites.outputs.available != 'true'
+        run: echo "::notice::Build smoke skipped: required publish artifacts are not available in this checkout."

--- a/OVERHAUL_STATUS.md
+++ b/OVERHAUL_STATUS.md
@@ -2,10 +2,10 @@
 
 This file tracks what we are actively working on in the overhaul branch.
 
-## Current Focus (Phase 5 CI Bootstrapping)
-- Add a minimal required status check workflow for PR merge safety
-- Align branch protection on `main` with the new CI context
-- Keep compatibility backlog visible while CI matures beyond governance checks
+## Current Focus (Phase 6 CI Build Smoke Expansion)
+- Add repository-aware build-smoke coverage to the CI workflow
+- Keep merge safety checks required while build smoke remains advisory until publish artifacts are standardized
+- Track open prerequisites for reliable project-wide smoke compilation
 - Keep monthly status checks visible and action-oriented
 
 ## High-Impact Reliability Backlog
@@ -19,7 +19,7 @@ This file tracks what we are actively working on in the overhaul branch.
 
 ## Open Follow-up Tasks
 - Keep status issue cadence alive and close issue #2 on phase transition
-- Expand CI checks from governance-only to include build smoke targets when references are available
+- Expand CI checks from governance-only to include build smoke checks with artifact detection in place
 - Complete remaining compatibility hardening and close remaining phase-2 backlog items
 
 ## Active Status Issue


### PR DESCRIPTION
## Scope
- Expand governance CI to include a repository-aware build smoke job.
- Skip build smoke when publish artifacts are not checked into the repo to avoid false failures in baseline-only environments.
- Keep runtime code unchanged and preserve required merge checks for Governance Smoke Check.