### PR TITLE
chore(overhaul): require build smoke check in branch protection

### DIFF
--- a/OVERHAUL_ROADMAP.md
+++ b/OVERHAUL_ROADMAP.md
@@ -41,3 +41,9 @@ This roadmap tracks the ongoing rewrite and stabilization effort.
 
 - [x] Add required-status-check workflow for governance/documentation safety
 - [x] Wire branch protection to require a deterministic CI check context
+
+## Phase 6 — CI smoke check expansion
+
+- [x] Add optional artifact-aware build smoke job
+- [x] Keep build smoke non-blocking until artifacts are standardized
+- [x] Document required check expectations for both governance and build jobs

--- a/OVERHAUL_STATUS.md
+++ b/OVERHAUL_STATUS.md
@@ -2,10 +2,10 @@
 
 This file tracks what we are actively working on in the overhaul branch.
 
-## Current Focus (Phase 6 CI Build Smoke Expansion)
-- Add repository-aware build-smoke coverage to the CI workflow
-- Keep merge safety checks required while build smoke remains advisory until publish artifacts are standardized
-- Track open prerequisites for reliable project-wide smoke compilation
+## Current Focus (Reliability Backlog Continuation)
+- Keep phase 6 CI checks enforced and documented
+- Prioritize `P1` cloud sync timeout handling and stalled-read handling
+- Prioritize `P2` downloader race-condition mitigation on resume/retry
 - Keep monthly status checks visible and action-oriented
 
 ## High-Impact Reliability Backlog
@@ -19,7 +19,7 @@ This file tracks what we are actively working on in the overhaul branch.
 
 ## Open Follow-up Tasks
 - Keep status issue cadence alive and close issue #2 on phase transition
-- Expand CI checks from governance-only to include build smoke checks with artifact detection in place
+- Add actual publish artifacts to CI pipeline for full build validation coverage
 - Complete remaining compatibility hardening and close remaining phase-2 backlog items
 
 ## Active Status Issue

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -36,6 +36,12 @@ gh api repos/SocialHummingbird/StS2-Launcher-Overhaul/branches/main/protection \
 When CI is available, prefer required status checks:
 
 - `Governance Smoke Check` (job: `governance-smoke` in `.github/workflows/overhaul-governance-ci.yml`)
+- `Build Smoke Check` (job: `build-smoke` in `.github/workflows/overhaul-governance-ci.yml`)
+
+Build smoke is intentionally safe-by-default:
+
+- it runs in advisory mode when publish artifacts are missing
+- it does not fail merge safety if the repo checkout does not include required assemblies yet
 
 If CI is not yet available, keep status-check enforcement off and switch it on when workflows are added.
 


### PR DESCRIPTION
## Scope
- Update branch protection docs and status tracking for new CI expectation.
- Require both Governance Smoke Check and Build Smoke Check on PRs to main.
- Keep runtime code untouched.