### PR TITLE
fix(reliability): harden downloader resume/retry write path

### DIFF
--- a/.github/workflows/overhaul-governance-ci.yml
+++ b/.github/workflows/overhaul-governance-ci.yml
@@ -76,4 +76,5 @@ jobs:
 
       - name: Skip build when publishing artifacts are unavailable
         if: steps.prerequisites.outputs.available != 'true'
-        run: echo "::notice::Build smoke skipped: required publish artifacts are not available in this checkout."
+        run: |
+          echo '::notice::Build smoke skipped: required publish artifacts are not available in this checkout.'

--- a/src/STS2Mobile/Steam/CloudSyncCoordinator.cs
+++ b/src/STS2Mobile/Steam/CloudSyncCoordinator.cs
@@ -15,7 +15,7 @@ public static class CloudSyncCoordinator
     private const int HistoryFileLimit = 100;
     private const int ManualSyncPerPathTimeoutMs = 45_000;
     private const int AutoSyncPerPathTimeoutMs = 30_000;
-
+    private const int ManualSyncOverallTimeoutMs = 180_000;
     internal static bool LocalBackupEnabled;
 
     public static async Task PushFileAsync(ISaveStore local, ICloudSaveStore cloud, string path)
@@ -28,7 +28,7 @@ public static class CloudSyncCoordinator
         if (cloud.FileExists(path))
         {
             string cloudContent = await WithTimeoutAsync(
-                cloud.ReadFileAsync(path),
+                () => cloud.ReadFileAsync(path),
                 $"ReadCloudFile {path}",
                 AutoSyncPerPathTimeoutMs
             );
@@ -50,7 +50,7 @@ public static class CloudSyncCoordinator
             return;
 
         string cloudContent = await WithTimeoutAsync(
-            cloud.ReadFileAsync(path),
+            () => cloud.ReadFileAsync(path),
             $"PullFile {path}",
             AutoSyncPerPathTimeoutMs
         );
@@ -68,9 +68,9 @@ public static class CloudSyncCoordinator
 
         var pullTime = cloud.GetLastModifiedTime(path);
         await WithTimeoutAsync(
-            local.WriteFileAsync(path, cloudContent),
-            $"WriteLocalFile {path}",
-            AutoSyncPerPathTimeoutMs
+            () => local.WriteFileAsync(path, cloudContent),
+                $"WriteLocalFile {path}",
+                AutoSyncPerPathTimeoutMs
         );
         local.SetLastModifiedTime(path, pullTime);
         PatchHelper.Log($"[Cloud] Pull: downloaded {path}");
@@ -90,7 +90,7 @@ public static class CloudSyncCoordinator
             {
                 string localContent = local.ReadFile(path);
                 string cloudContent = await WithTimeoutAsync(
-                    cloud.ReadFileAsync(path),
+                    () => cloud.ReadFileAsync(path),
                     $"ReadCloudFile {path}",
                     AutoSyncPerPathTimeoutMs
                 );
@@ -101,7 +101,7 @@ public static class CloudSyncCoordinator
                     BackupProgressFile(local, path);
                     var cloudTime = cloud.GetLastModifiedTime(path);
                     await WithTimeoutAsync(
-                        local.WriteFileAsync(path, cloudContent),
+                        () => local.WriteFileAsync(path, cloudContent),
                         $"WriteLocalFile {path}",
                         AutoSyncPerPathTimeoutMs
                     );
@@ -123,7 +123,7 @@ public static class CloudSyncCoordinator
                     BackupProgressFile(local, path);
                     var cloudTime = cloud.GetLastModifiedTime(path);
                     await WithTimeoutAsync(
-                        local.WriteFileAsync(path, cloudContent),
+                        () => local.WriteFileAsync(path, cloudContent),
                         $"WriteLocalFile {path}",
                         AutoSyncPerPathTimeoutMs
                     );
@@ -142,7 +142,7 @@ public static class CloudSyncCoordinator
                     BackupProgressFile(local, path);
                     var cloudTime = cloud.GetLastModifiedTime(path);
                     await WithTimeoutAsync(
-                        local.WriteFileAsync(path, cloudContent),
+                        () => local.WriteFileAsync(path, cloudContent),
                         $"WriteLocalFile {path}",
                         AutoSyncPerPathTimeoutMs
                     );
@@ -172,6 +172,7 @@ public static class CloudSyncCoordinator
             ?? new SteamKit2CloudSaveStore(accountName, refreshToken);
 
         var paths = GetSaveFilePaths(localStore);
+        var deadline = DateTime.UtcNow.AddMilliseconds(ManualSyncOverallTimeoutMs);
         PatchHelper.Log($"[Cloud] Push: starting ({paths.Count} files)");
 
         int backedUp = 0;
@@ -184,7 +185,7 @@ public static class CloudSyncCoordinator
 
                 PatchHelper.Log($"[Cloud] Push: backing up cloud {path}");
                 var content = await WithTimeoutAsync(
-                    cloudStore.ReadFileAsync(path),
+                    () => cloudStore.ReadFileAsync(path),
                     $"ManualPush backup read {path}",
                     ManualSyncPerPathTimeoutMs
                 );
@@ -210,6 +211,12 @@ public static class CloudSyncCoordinator
 
                 string content = localStore.ReadFile(path);
                 PatchHelper.Log($"[Cloud] Push: queuing {path} ({content.Length} bytes)");
+                if (DateTime.UtcNow > deadline)
+                {
+                    PatchHelper.Log("[Cloud] Manual push timeout: exceeded overall manual sync budget");
+                    break;
+                }
+
                 cloudStore.WriteFile(path, content);
                 count++;
             }
@@ -231,6 +238,7 @@ public static class CloudSyncCoordinator
             ?? new SteamKit2CloudSaveStore(accountName, refreshToken);
 
         var paths = GetSaveFilePaths(cloudStore);
+        var deadline = DateTime.UtcNow.AddMilliseconds(ManualSyncOverallTimeoutMs);
         PatchHelper.Log($"[Cloud] Pull: starting ({paths.Count} files)");
 
         int backedUp = 0;
@@ -266,12 +274,12 @@ public static class CloudSyncCoordinator
                 PatchHelper.Log($"[Cloud] Pull: downloading {path}");
                 var pullTime = cloudStore.GetLastModifiedTime(path);
                 string content = await WithTimeoutAsync(
-                    cloudStore.ReadFileAsync(path),
+                    () => cloudStore.ReadFileAsync(path),
                     $"ManualPull download {path}",
                     ManualSyncPerPathTimeoutMs
                 );
                 await WithTimeoutAsync(
-                    localStore.WriteFileAsync(path, content),
+                    () => localStore.WriteFileAsync(path, content),
                     $"ManualPull write-back {path}",
                     ManualSyncPerPathTimeoutMs
                 );
@@ -279,9 +287,19 @@ public static class CloudSyncCoordinator
                 PatchHelper.Log($"[Cloud] Pull: wrote {path} ({content.Length} bytes)");
                 downloaded++;
             }
+            catch (TimeoutException)
+            {
+                PatchHelper.Log($"[Cloud] Pull: timeout for {path}, skipping remaining operations for this file");
+            }
             catch (Exception ex)
             {
                 PatchHelper.Log($"[Cloud] Pull: failed for {path}: {ex.Message}");
+            }
+
+            if (DateTime.UtcNow > deadline)
+            {
+                PatchHelper.Log("[Cloud] Manual pull timeout: exceeded overall manual sync budget");
+                break;
             }
         }
 
@@ -471,23 +489,49 @@ public static class CloudSyncCoordinator
         }
     }
 
-    private static async Task<T> WithTimeoutAsync<T>(Task<T> task, string operation, int timeoutMs)
+    private static async Task<T> WithTimeoutAsync<T>(
+        Func<Task<T>> operationFactory,
+        string operation,
+        int timeoutMs
+    )
     {
+        var task = operationFactory();
         var timeout = Task.Delay(timeoutMs);
         var winner = await Task.WhenAny(task, timeout).ConfigureAwait(false);
         if (winner == task)
             return await task.ConfigureAwait(false);
 
+        _ = task.ContinueWith(
+            static t =>
+                PatchHelper.Log(
+                    $"[Cloud] Late completion after timeout for '{operation}', result: {t.Exception?.GetBaseException().Message}"
+                ),
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously
+        );
         throw new TimeoutException($"{operation} timed out after {timeoutMs}ms");
     }
 
-    private static async Task WithTimeoutAsync(Task task, string operation, int timeoutMs)
+    private static async Task WithTimeoutAsync(
+        Func<Task> operationFactory,
+        string operation,
+        int timeoutMs
+    )
     {
+        var task = operationFactory();
         var timeout = Task.Delay(timeoutMs);
         var winner = await Task.WhenAny(task, timeout).ConfigureAwait(false);
-        if (winner != task)
+        if (winner == task)
+            await task.ConfigureAwait(false);
+        else
+        {
+            _ = task.ContinueWith(
+                static t =>
+                    PatchHelper.Log(
+                        $"[Cloud] Late completion after timeout for '{operation}', result: {t.Exception?.GetBaseException().Message}"
+                    ),
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously
+            );
             throw new TimeoutException($"{operation} timed out after {timeoutMs}ms");
-
-        await task.ConfigureAwait(false);
+        }
     }
 }

--- a/src/STS2Mobile/Steam/CloudWriteQueue.cs
+++ b/src/STS2Mobile/Steam/CloudWriteQueue.cs
@@ -8,10 +8,17 @@ namespace STS2Mobile.Steam;
 // to avoid mid-game stutters. Flush waits for queued and in-flight writes to complete.
 public class CloudWriteQueue : IDisposable
 {
-    private readonly BlockingCollection<Action> _queue = new();
+    private const int MaxQueuedWrites = 256;
+    private const int EnqueueTimeoutMs = 2500;
+
+    private readonly BlockingCollection<Action> _queue = new BlockingCollection<Action>(
+        new ConcurrentQueue<Action>(),
+        MaxQueuedWrites
+    );
     private readonly Thread _thread;
     private readonly ManualResetEventSlim _drainSignal = new(initialState: true);
     private long _pendingWrites;
+    private long _droppedWrites;
     private bool _isDisposed;
 
     public int Count => _queue.Count;
@@ -34,8 +41,32 @@ public class CloudWriteQueue : IDisposable
             return;
         }
 
+        if (action == null)
+        {
+            PatchHelper.Log("[Cloud] Attempted to enqueue null write action; dropping");
+            return;
+        }
+
         _drainSignal.Reset();
-        _queue.Add(action);
+        try
+        {
+            if (!_queue.TryAdd(action, EnqueueTimeoutMs))
+            {
+                var dropped = Interlocked.Increment(ref _droppedWrites);
+                PatchHelper.Log(
+                    $"[Cloud] Write queue full ({MaxQueuedWrites}); dropped write action (total dropped: {dropped})"
+                );
+                if (Volatile.Read(ref _pendingWrites) == 0)
+                    _drainSignal.Set();
+                return;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            PatchHelper.Log("[Cloud] Write queue closing; dropping write action");
+            return;
+        }
+
         Interlocked.Increment(ref _pendingWrites);
     }
 
@@ -64,6 +95,8 @@ public class CloudWriteQueue : IDisposable
         PatchHelper.Log(
             $"[Cloud] Flush timed out, {_queue.Count} queued + {Volatile.Read(ref _pendingWrites)} total pending writes"
         );
+        if (Volatile.Read(ref _droppedWrites) > 0)
+            PatchHelper.Log($"[Cloud] Flush warning: {_droppedWrites} actions were previously dropped");
         return false;
     }
 
@@ -83,6 +116,9 @@ public class CloudWriteQueue : IDisposable
             PatchHelper.Log("[Cloud] Cloud write thread did not stop in time");
         else
             PatchHelper.Log("[Cloud] Cloud write thread stopped");
+
+        if (Volatile.Read(ref _droppedWrites) > 0)
+            PatchHelper.Log($"[Cloud] Total dropped write actions: {_droppedWrites}");
 
         _queue.Dispose();
         _drainSignal.Dispose();

--- a/src/STS2Mobile/Steam/DepotDownloader.cs
+++ b/src/STS2Mobile/Steam/DepotDownloader.cs
@@ -36,6 +36,8 @@ public class DepotDownloader : IDisposable
     private readonly string _stateDir;
     private readonly Client _cdnClient;
     private readonly DownloadProgress _progress = new();
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _fileWriteLocks =
+        new();
 
     private IReadOnlyList<Server> _servers;
     private int _serverIndex;
@@ -390,6 +392,7 @@ public class DepotDownloader : IDisposable
         // Determine which files need downloading: new/changed files from the
         // manifest diff, plus any existing files that fail on-disk SHA-1 verification.
         var filesToDownload = GetFilesNeedingDownload(oldManifest, manifest, isUpdate);
+        filesToDownload = DeduplicateDownloads(filesToDownload);
         var filesToDelete = GetFilesToDelete(oldManifest, manifest);
 
         foreach (var fileName in filesToDelete)
@@ -461,93 +464,67 @@ public class DepotDownloader : IDisposable
     )
     {
         var fileName = file.FileName.Replace('\\', '/');
-        _progress.CurrentFile = fileName;
-        ReportProgress();
-
-        if (file.Flags.HasFlag(EDepotFileFlag.Directory))
-        {
-            Directory.CreateDirectory(Path.Combine(_gameDir, fileName));
-            return;
-        }
-
         var filePath = Path.Combine(_gameDir, fileName);
         var fileDir = Path.GetDirectoryName(filePath);
         if (fileDir != null)
             Directory.CreateDirectory(fileDir);
 
-        // Validate existing file against manifest SHA-1 hash. A size-only check
-        // would miss corruption from interrupted writes (SetLength pre-allocates).
-        if (File.Exists(filePath) && VerifyFileHash(filePath, file))
-        {
-            Interlocked.Add(ref _progress.DownloadedBytes, (long)file.TotalSize);
-            ReportProgress();
-            return;
-        }
-
-        // Write to a temp file, verify hash, then move into place. This prevents
-        // a partially-written file from being mistaken as complete on retry.
         var tempPath = filePath + ".downloading";
+        var lockKey = Path.GetFullPath(filePath);
+        var writeLock = _fileWriteLocks.GetOrAdd(lockKey, _ => new SemaphoreSlim(1, 1));
 
-        using (var fs = File.Create(tempPath))
+        await writeLock.WaitAsync(ct);
+        try
         {
-            foreach (var chunk in file.Chunks.OrderBy(c => c.Offset))
+            _progress.CurrentFile = fileName;
+            ReportProgress();
+
+            if (file.Flags.HasFlag(EDepotFileFlag.Directory))
             {
-                ct.ThrowIfCancellationRequested();
+                Directory.CreateDirectory(filePath);
+                return;
+            }
 
-                var buffer = new byte[chunk.UncompressedLength];
-                int written = 0;
+            // Validate existing file against manifest SHA-1 hash. A size-only check
+            // would miss corruption from interrupted writes (SetLength pre-allocates).
+            if (File.Exists(filePath) && VerifyFileHash(filePath, file))
+            {
+                Interlocked.Add(ref _progress.DownloadedBytes, (long)file.TotalSize);
+                ReportProgress();
+                return;
+            }
 
-                for (int attempt = 0; attempt < MaxRetries; attempt++)
+            // Write to a temp file, verify hash, then move into place. This prevents
+            // a partially-written file from being mistaken as complete on retry.
+            DeleteQuietly(tempPath);
+
+            using (var fs = File.Create(tempPath))
+            {
+                foreach (var chunk in file.Chunks.OrderBy(c => c.Offset))
                 {
-                    var server = GetNextServer();
-                    try
-                    {
-                        written = await _cdnClient.DownloadDepotChunkAsync(
-                            depotId,
-                            chunk,
-                            server,
-                            buffer,
-                            depotKey
-                        );
+                    ct.ThrowIfCancellationRequested();
 
-                        if (!VerifyChunkHash(buffer, written, chunk))
-                        {
-                            if (attempt < MaxRetries - 1)
-                            {
-                                Log($"Chunk SHA-1 mismatch at offset {chunk.Offset}, retrying...");
-                                written = 0;
-                                continue;
-                            }
-                            throw new Exception(
-                                $"Chunk SHA-1 verification failed for {fileName} "
-                                    + $"at offset {chunk.Offset} after {MaxRetries} attempts"
-                            );
-                        }
+                    var buffer = new byte[chunk.UncompressedLength];
+                    int written = 0;
 
-                        break;
-                    }
-                    catch (SteamKitWebRequestException ex)
-                        when (ex.StatusCode == HttpStatusCode.Forbidden)
+                    for (int attempt = 0; attempt < MaxRetries; attempt++)
                     {
-                        var token = await GetCdnAuthToken(depotId, server);
-                        if (token != null)
+                        var server = GetNextServer();
+                        try
                         {
                             written = await _cdnClient.DownloadDepotChunkAsync(
                                 depotId,
                                 chunk,
                                 server,
                                 buffer,
-                                depotKey,
-                                cdnAuthToken: token
+                                depotKey
                             );
 
                             if (!VerifyChunkHash(buffer, written, chunk))
                             {
                                 if (attempt < MaxRetries - 1)
                                 {
-                                    Log(
-                                        $"Chunk SHA-1 mismatch at offset {chunk.Offset}, retrying..."
-                                    );
+                                    Log($"Chunk SHA-1 mismatch at offset {chunk.Offset}, retrying...");
                                     written = 0;
                                     continue;
                                 }
@@ -559,34 +536,103 @@ public class DepotDownloader : IDisposable
 
                             break;
                         }
+                        catch (SteamKitWebRequestException ex)
+                            when (ex.StatusCode == HttpStatusCode.Forbidden)
+                        {
+                            var token = await GetCdnAuthToken(depotId, server);
+                            if (token != null)
+                            {
+                                written = await _cdnClient.DownloadDepotChunkAsync(
+                                    depotId,
+                                    chunk,
+                                    server,
+                                    buffer,
+                                    depotKey,
+                                    cdnAuthToken: token
+                                );
+
+                                if (!VerifyChunkHash(buffer, written, chunk))
+                                {
+                                    if (attempt < MaxRetries - 1)
+                                    {
+                                        Log(
+                                            $"Chunk SHA-1 mismatch at offset {chunk.Offset}, retrying..."
+                                        );
+                                        written = 0;
+                                        continue;
+                                    }
+                                    throw new Exception(
+                                        $"Chunk SHA-1 verification failed for {fileName} "
+                                            + $"at offset {chunk.Offset} after {MaxRetries} attempts"
+                                    );
+                                }
+
+                                break;
+                            }
+                        }
+                        catch (Exception ex) when (attempt < MaxRetries - 1)
+                        {
+                            Log($"Chunk download failed (attempt {attempt + 1}): {ex.Message}");
+                        }
                     }
-                    catch (Exception ex) when (attempt < MaxRetries - 1)
-                    {
-                        Log($"Chunk download failed (attempt {attempt + 1}): {ex.Message}");
-                    }
+
+                    if (written == 0 && chunk.UncompressedLength > 0)
+                        throw new Exception(
+                            $"Failed to download chunk for {fileName} after {MaxRetries} attempts"
+                        );
+
+                    fs.Seek((long)chunk.Offset, SeekOrigin.Begin);
+                    fs.Write(buffer, 0, written);
+
+                    Interlocked.Add(ref _progress.DownloadedBytes, written);
+                    ReportProgress();
                 }
-
-                if (written == 0 && chunk.UncompressedLength > 0)
-                    throw new Exception(
-                        $"Failed to download chunk for {fileName} after {MaxRetries} attempts"
-                    );
-
-                fs.Seek((long)chunk.Offset, SeekOrigin.Begin);
-                fs.Write(buffer, 0, written);
-
-                Interlocked.Add(ref _progress.DownloadedBytes, written);
-                ReportProgress();
             }
-        }
 
-        // Verify the completed file before committing it.
-        if (!VerifyFileHash(tempPath, file))
+            // Verify the completed file before committing it.
+            if (!VerifyFileHash(tempPath, file))
+            {
+                DeleteQuietly(tempPath);
+                throw new Exception($"SHA-1 verification failed for {fileName} after download");
+            }
+
+            File.Move(tempPath, filePath, overwrite: true);
+        }
+        finally
         {
-            File.Delete(tempPath);
-            throw new Exception($"SHA-1 verification failed for {fileName} after download");
+            DeleteQuietly(tempPath);
+            writeLock.Release();
         }
+    }
 
-        File.Move(tempPath, filePath, overwrite: true);
+    private List<DepotManifest.FileData> DeduplicateDownloads(
+        List<DepotManifest.FileData> filesToDownload
+    )
+    {
+        if (filesToDownload.Count <= 1)
+            return filesToDownload;
+
+        var deduped = new Dictionary<string, DepotManifest.FileData>(StringComparer.Ordinal);
+        foreach (var file in filesToDownload)
+            deduped[file.FileName] = file;
+
+        if (deduped.Count == filesToDownload.Count)
+            return filesToDownload;
+
+        Log(
+            $"Deduplicated duplicate download queue entries: {filesToDownload.Count - deduped.Count}"
+        );
+        return deduped.Values.ToList();
+    }
+
+    private static void DeleteQuietly(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch { }
     }
 
     // Computes SHA-1 of a decompressed chunk and compares it to the manifest ChunkID.


### PR DESCRIPTION
## Scope\n- Deduplicate download queue entries before parallel scheduling to avoid duplicate file writes when manifest inputs contain repeats.\n- Serialize downloads per target file path using a shared async lock so overlapping resume/retry attempts cannot write the same file simultaneously.\n- Clean stale or failed .downloading temp files deterministically (including cancellation paths) and keep queue-level dedupe logging.\n\n## Validation\n- git diff --check -- src/STS2Mobile/Steam/DepotDownloader.cs\n