### PR TITLE
fix(overhaul): harden startup crash paths and locale parsing

### DIFF
--- a/OVERHAUL_STATUS.md
+++ b/OVERHAUL_STATUS.md
@@ -4,8 +4,8 @@ This file tracks what we are actively working on in the overhaul branch.
 
 ## Current Focus (Reliability Backlog Continuation)
 - Keep phase 6 CI checks enforced and documented
-- Prioritize `P1` cloud sync timeout handling and stalled-read handling
-- Prioritize `P2` downloader race-condition mitigation on resume/retry
+- Land `P0` startup crash-path hardening (`codex/p0-startup-crash-hardening`) in PR review
+- Next after merge: `P3` multiplayer LAN discovery/broadcast stability (current open gap)
 - Keep monthly status checks visible and action-oriented
 
 ## High-Impact Reliability Backlog

--- a/src/STS2Mobile/Patches/ModelDbInitPatch.cs
+++ b/src/STS2Mobile/Patches/ModelDbInitPatch.cs
@@ -44,7 +44,18 @@ public static class ModelDbInitPatch
             "AllAbstractModelSubtypes",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static
         );
+        if (allSubtypesProp == null)
+        {
+            PatchHelper.Log("ModelDb.Init fallback: AllAbstractModelSubtypes property missing");
+            return true;
+        }
+
         var types = (Type[])allSubtypesProp.GetValue(null);
+        if (types == null || types.Length == 0)
+        {
+            PatchHelper.Log("ModelDb.Init fallback: no model subtypes were exposed");
+            return true;
+        }
 
         var getIdMethod = modelDbType.GetMethod(
             "GetId",
@@ -53,15 +64,36 @@ public static class ModelDbInitPatch
             new[] { typeof(Type) },
             null
         );
+        if (getIdMethod == null)
+        {
+            PatchHelper.Log("ModelDb.Init fallback: GetId method missing");
+            return true;
+        }
 
         var contentByIdField = modelDbType.GetField(
             "_contentById",
             BindingFlags.NonPublic | BindingFlags.Static
         );
+        if (contentByIdField == null)
+        {
+            PatchHelper.Log("ModelDb.Init fallback: _contentById field missing");
+            return true;
+        }
+
         var contentById = contentByIdField.GetValue(null);
+        if (contentById == null)
+        {
+            PatchHelper.Log("ModelDb.Init fallback: _contentById is null");
+            return true;
+        }
 
         var dictType = contentById.GetType();
         var setItemMethod = dictType.GetMethod("set_Item");
+        if (setItemMethod == null)
+        {
+            PatchHelper.Log("ModelDb.Init fallback: _contentById.set_Item method missing");
+            return true;
+        }
 
         // Phase 1: Pre-populate dictionary with uninitialized objects
         PatchHelper.Log(
@@ -100,10 +132,20 @@ public static class ModelDbInitPatch
             new[] { typeof(Type) },
             null
         );
+        if (containsMethod == null)
+        {
+            PatchHelper.Log("ModelDb.Init fallback: Contains(Type) method missing");
+            return true;
+        }
         var containsPrefix = typeof(ModelDbInitPatch).GetMethod(
             nameof(ContainsPrefix),
             BindingFlags.Public | BindingFlags.Static
         );
+        if (containsPrefix == null)
+        {
+            PatchHelper.Log("ModelDb.Init fallback: ContainsPrefix method missing");
+            return true;
+        }
         harmony.Patch(containsMethod, new HarmonyMethod(containsPrefix));
 
         // Phase 2: Run constructors on pre-allocated objects

--- a/src/STS2Mobile/Patches/PlatformPatches.cs
+++ b/src/STS2Mobile/Patches/PlatformPatches.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -54,9 +55,8 @@ public static class PlatformPatches
             prefix: PatchHelper.Method(typeof(PlatformPatches), nameof(SkipPrefix))
         );
 
-        // Android 16 uses extended locale identifiers with Unicode extensions
-        // (e.g. "de-DE-u-mu-celsius") which .NET's CultureInfo cannot parse,
-        // crashing the localization system and preventing the game from loading.
+        // Android locale tags can include Unicode/private-use extensions that
+        // some .NET runtimes fail to parse directly.
         PatchGetThreeLetterLanguageCode(harmony);
     }
 
@@ -125,17 +125,26 @@ public static class PlatformPatches
         }
     }
 
-    // Strip Unicode extension subtags (e.g. "-u-mu-celsius") from the locale
-    // string before passing it to CultureInfo, which doesn't understand them.
+    // Keep locale resolution resilient across unusual BCP-47 tags and malformed data.
     public static bool GetThreeLetterLanguageCodePrefix(ref string __result)
     {
         try
         {
             var locale = Godot.OS.GetLocale(); // e.g. "de_DE_u_mu_celsius" or "de_DE"
-            var sanitized = StripUnicodeExtensions(locale.Replace('_', '-'));
-            PatchHelper.Log($"Locale fix: raw='{locale}' sanitized='{sanitized}'");
-            var culture = new CultureInfo(sanitized);
-            __result = culture.ThreeLetterISOLanguageName;
+            foreach (var cultureName in EnumerateLocaleCandidates(locale))
+            {
+                if (TryResolveThreeLetterCulture(cultureName, out var threeLetter))
+                {
+                    __result = threeLetter;
+                    PatchHelper.Log(
+                        $"Locale fix: resolved '{locale}' -> '{cultureName}' -> '{__result}'"
+                    );
+                    return false;
+                }
+            }
+
+            PatchHelper.Log("Locale fix: no locale candidates resolved, fallback to 'eng'");
+            __result = "eng";
         }
         catch (Exception ex)
         {
@@ -145,11 +154,60 @@ public static class PlatformPatches
         return false;
     }
 
-    // Strips Unicode BCP 47 extension subtags: everything from "-u-" onward.
-    // "de-DE-u-mu-celsius" → "de-DE", "en-US" → "en-US"
-    private static string StripUnicodeExtensions(string locale)
+    private static bool TryResolveThreeLetterCulture(string locale, out string threeLetter)
     {
-        var idx = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
+        threeLetter = null;
+        var trimmed = locale?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+            return false;
+
+        try
+        {
+            var culture = new CultureInfo(trimmed);
+            threeLetter = culture.ThreeLetterISOLanguageName;
+            return !string.IsNullOrWhiteSpace(threeLetter);
+        }
+        catch (CultureNotFoundException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    // Generates candidate locale strings from most specific to broadest fallback.
+    private static IEnumerable<string> EnumerateLocaleCandidates(string locale)
+    {
+        var raw = (locale ?? string.Empty).Trim().Replace('_', '-');
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            yield return "eng";
+            yield break;
+        }
+
+        var sanitized = StripExtension(raw, "-u-");
+        sanitized = StripExtension(sanitized, "-x-");
+
+        yield return sanitized;
+
+        var firstToken = sanitized.Split('-')[0];
+        if (!string.IsNullOrWhiteSpace(firstToken) && !string.Equals(firstToken, sanitized))
+            yield return firstToken;
+
+        var tokens = sanitized.Split('-');
+        if (tokens.Length > 1)
+            yield return tokens[0];
+
+        yield return "eng";
+    }
+
+    // Strips BCP-47 extension subtags like "-u-" (Unicode) and "-x-" (private use).
+    private static string StripExtension(string locale, string extensionMarker)
+    {
+        var idx = locale.IndexOf(extensionMarker, StringComparison.OrdinalIgnoreCase);
         return idx >= 0 ? locale.Substring(0, idx) : locale;
     }
 }


### PR DESCRIPTION
## Summary
- Guard ModelDb.Init reflection paths with safe fallback checks to avoid hard crash when upstream internals drift.
- Improve locale resolution in PlatformPatches with resilient candidate parsing and explicit fallback to `eng`.

Validation:
- `git diff --check -- src/STS2Mobile/Patches/ModelDbInitPatch.cs src/STS2Mobile/Patches/PlatformPatches.cs`