### PR TITLE
Update Android release docs for v0.2.184

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # StS2 Launcher Overhaul
 
+<p align="center">
+  <img src="docs/assets/sts2-launcher-icon.svg" alt="StS2 Launcher icon" width="128" height="128">
+</p>
+
 ## Project note (independent copy)
 
 This repository is a full copy of [Ekyso/StS2-Launcher](https://github.com/Ekyso/StS2-Launcher), created to continue and broaden development as a focused rewrite project.
@@ -14,6 +18,7 @@ The goal is a **drastic architecture and reliability overhaul** that is harder t
 - Changelog: [CHANGELOG.md](CHANGELOG.md)
 - Device log checklist: [docs/device-log-checklist.md](docs/device-log-checklist.md)
 - Android runtime findings: [docs/android-runtime-findings.md](docs/android-runtime-findings.md)
+- Current Android status: [docs/current-android-status.md](docs/current-android-status.md)
 
 ### Suggested working remotes
 
@@ -29,14 +34,31 @@ An Android launcher for Slay the Spire 2, built on a custom Godot 4.5.1 engine w
 
 > **Disclaimer**: This is an unofficial community project. Slay the Spire 2 is developed and published by Mega Crit Games. A valid Steam account that owns Slay the Spire 2 is required. Game files are downloaded directly from Steam after authentication. No game assets are included in this repository.
 
+## Current Status
+
+**Working ARM64 Android baseline:** the launcher now installs, starts, authenticates with Steam, downloads game files, pulls Steam Cloud saves into Android local app storage, pushes Android saves back to Steam Cloud on the local hardening build, and launches the game with the pulled profile visible in-game.
+
+This is still a polish and hardening phase, not release-candidate signoff. The active work is focused on broader Samsung/One UI retesting, persisted Steam-session/update UX, richer loading/progress surfaces, quieter diagnostics, and repeatable release asset hygiene.
+
+- Latest published APK release: `v0.2.184-loading-scale`
+- Current APK asset: `StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk`
+- Package name: `com.sts2launcher.overhaul.fork.dev`
+- Release asset SHA-256: `299f77e9c307b64521ffef73afb890fb2c69bb7a920bf7d24c971cf0b6663f2d`
+- Latest verified public release: `0.2.184-loading-scale` / `versionCode=218400`
+- Validated locally/publicly: fresh APK/runtime install, public `v0.2.183 -> v0.2.184` update-compatible release build, launcher startup visual check on ARM64 hardware, Steam login to Steam Guard on public `v0.2.183`, Steam game download, Pull from Cloud, Push to Cloud, Pull-after-Push round trip, Android local save handoff, game launch/profile visibility, and restart-to-launcher behavior on ARM64 hardware.
+- Still hardening: Samsung A53/S25+/S24 Ultra reporter retests, repeated public-release Pull/Push/game-launch smoke on the newest APK, persisted Steam session/update UX, richer launch progress UI, diagnostics polish, and release-candidate signoff.
+- Emulator limitation: Android `x86_64` is fallback/diagnostic coverage only. ARM64 hardware remains the proof target.
+
+See [docs/current-android-status.md](docs/current-android-status.md) for the current evidence and remaining blockers.
+
 ## Features
 
 - **Steam authentication**  
-  Login via SteamKit2 with Steam Guard 2FA support.
+  Login via SteamKit2 with Steam Guard 2FA support. ARM64 device validation has progressed through authenticated download, cloud pull, local hardening Push, and game launch; release hardening is still ongoing.
 - **Game file download**  
   Depot download directly from Steam, with update checking.
 - **Cloud saves**  
-  Full Steam cloud sync via SteamKit2's CCloud API, with timestamp-aware conflict resolution and non-blocking background uploads.
+  Steam cloud sync via SteamKit2's CCloud API, with timestamp-aware conflict resolution and non-blocking background uploads. Pull from Cloud, Push to Cloud, and Pull-after-Push round trip are validated on ARM64 local hardening builds. Push remains an explicit overwrite-risk action because it can replace Steam Cloud state.
 - **Mobile adaptation**  
   Touch input, UI scaling, layout adjustments, and app lifecycle handling via Harmony runtime patches.
 - **LAN multiplayer**  
@@ -133,7 +155,7 @@ Verify a local archived APK from `artifacts/android/`:
 sha256sum -c StS2Launcher-v0.2.0-local-arm64-arm64-v8a.apk.sha256
 ```
 
-The Android `x86_64` emulator is useful for install, routing, release packaging, and native diagnostic-screen testing, but it is not a valid proof target for the Godot/.NET launcher or downloaded game. `x86_64` routes to a native fallback screen instead of starting Godot, because the emulator path crashes inside the Mono/GodotSharp native runtime. Use an `arm64-v8a` Android device/build to test Steam login, download, and actual game launch.
+The Android `x86_64` emulator is useful for install, routing, release packaging, and native diagnostic-screen testing, but it is not a valid proof target for the Godot/.NET launcher or downloaded game. `x86_64` routes to a native fallback screen instead of starting Godot, because the emulator path crashes inside the Mono/GodotSharp native runtime. A forced-Godot emulator run can still crash with native runtime failures such as destroyed mutex access. Use an `arm64-v8a` Android device/build to test Steam login, download, and actual game launch.
 
 ### Local Android smoke test
 
@@ -173,7 +195,7 @@ adb install -r android/build/outputs/apk/mono/release/StS2Launcher-v*.apk
 # Fresh install for local build wrapper default package
 adb shell pm clear com.sts2launcher.overhaul.fork.dev
 
-# Fresh install for production/release package
+# Fresh install for future production package, if used
 adb shell pm clear com.sts2launcher.overhaul.fork
 ```
 
@@ -182,46 +204,80 @@ adb shell pm clear com.sts2launcher.overhaul.fork
 GitHub Actions now builds Android APKs and publishes them to Releases.
 
 1. Open the repository **Releases** page: https://github.com/SocialHummingbird/StS2-Launcher-Overhaul/releases
-2. Download the universal APK for the latest release. Prefer the asset with `universal` in the filename for phones.
+2. Download the APK for the latest release.
     - Direct latest URL: https://github.com/SocialHummingbird/StS2-Launcher-Overhaul/releases/latest
-    - Downloaded artifact names include:
-      - `StS2Launcher-v<version>-universal.apk` or similar (recommended installable package for phones)
-      - `StS2Launcher-v<version>-arm64-v8a.apk` or similar (ARM64-only test package)
-      - `StS2Launcher-v<version>-x86_64.apk` or similar (emulator-only test package)
+    - Current release assets are ARM64-only test packages, named like:
+      - `StS2Launcher-v<version>-arm64-v8a.apk`
+    - Older releases may include universal or x86_64 assets. Prefer ARM64 for phones.
 
-Current verified phone release:
+Current published APK release:
 
 ```powershell
-.\scripts\verify-android-release-apk.ps1
-.\scripts\install-android-release.ps1 -ClearAppData -Launch -CaptureDiagnostics
+.\scripts\verify-android-release-apk.ps1 `
+  -ReleaseTag "v0.2.184-loading-scale" `
+  -AssetName "StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk" `
+  -Abi arm64-v8a
+
+.\scripts\install-android-release.ps1 `
+  -ReleaseTag "v0.2.184-loading-scale" `
+  -AssetName "StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk" `
+  -ClearAppData `
+  -Launch `
+  -CaptureDiagnostics
 ```
 
-Defaults:
+Release details:
 
 ```text
-Release: v0.2.88-apk-native-verify
-Asset: StS2Launcher-v0.2.88-universal-phone.apk
+Release: v0.2.184-loading-scale
+Asset: StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk
 Package: com.sts2launcher.overhaul.fork.dev
+SHA-256: 299f77e9c307b64521ffef73afb890fb2c69bb7a920bf7d24c971cf0b6663f2d
 ```
 
-The verifier downloads the GitHub release asset, checks its release SHA-256 digest, confirms both `arm64-v8a` and `x86_64` native libraries are present, and checks that `libgodot_android.so` contains the Android app-data .NET assembly lookup marker rather than the stale PCK lookup marker.
-      - `*.apk.sha256` (optional checksum)
-3. (Optional) Verify checksum:
+The verifier downloads the GitHub release asset, checks its release SHA-256 digest, confirms the expected native libraries are present, and checks that `libgodot_android.so` contains the Android app-data .NET assembly lookup marker rather than the stale PCK lookup marker.
+
+Safe public trial checklist:
+
+1. Use an ARM64 Android phone. Current public APKs are not x86_64 emulator proof.
+2. Install the latest GitHub release APK from the Releases page.
+3. Log in only with a Steam account that owns Slay the Spire 2.
+4. Download the game through the launcher.
+5. Use Pull from Cloud before Push to Cloud.
+6. Confirm Android local saves/profiles exist before using Push to Cloud.
+7. Treat Push to Cloud as destructive: it makes Steam Cloud reflect Android local saves and can overwrite remote save state.
+
+Support boundaries for public testers:
+
+- This is an unofficial community launcher and does not include game assets.
+- Do not post Steam credentials, guard codes, refresh tokens, private save data, or full unsanitized logs in public issues or Reddit threads.
+- Current support target is ARM64 Android hardware. x86_64 emulator behavior is diagnostic-only.
+- If reporting a cloud-save issue, say whether you used Pull or Push, but scrub usernames, account IDs, and save contents first.
+
+3. Optional manual checksum verification:
 
 ```bash
-sha256sum -c StS2Launcher-vX.Y.Z.apk.sha256
+sha256sum -c StS2Launcher-vX.Y.Z-arm64-v8a.apk.sha256
 ```
 
-4. Install on your phone:
+4. Optional manual install:
 
 ```bash
-adb install -r StS2Launcher-vX.Y.Z.apk
+adb install -r StS2Launcher-vX.Y.Z-arm64-v8a.apk
 ```
 
-Signed vs unsigned behavior:
+Signing behavior:
 
-- Signed release (production): generated when repository signing secrets are configured.
-- Unsigned release (testing): generated when signing secrets are missing; install works for test devices only and may trigger OS security warnings on fresh devices.
+- Published APK releases require repository signing secrets and a pinned release signer fingerprint.
+- The release workflow refuses to publish a temporary-key APK because it would not update existing installs safely.
+
+Known current runtime limitations:
+
+- The app now has a validated working ARM64 path through download, cloud pull, cloud push hardening, and game launch, but this is not yet a finished release-candidate pass.
+- Push to Cloud is locally validated after the managed SHA-1 hardening fix, and that fix is included in the verified public APK line. Repeat Push confirmation/cancel smoke on the newest public APK is still required before release-candidate signoff.
+- The public release package has passed update-compatible release builds through `v0.2.184-loading-scale`; repeated local `.local` in-place upgrade coverage remains secondary because local builds use a separate package identity.
+- Stale assembly cache behavior still needs repeated local upgrade coverage after signing continuity is fixed.
+- `x86_64` emulator validation is fallback/diagnostic coverage only unless explicitly forcing Godot for crash investigation.
 
 ### Release install troubleshooting
 
@@ -231,17 +287,16 @@ If installation fails:
   - likely a partially downloaded APK or signing mismatch.
   - re-download and re-run `sha256sum -c`.
 - `INSTALL_FAILED_UPDATE_INCOMPATIBLE`:
-  - remove previous app install first, then reinstall (this fork now uses package `com.sts2launcher.overhaul.fork`):
+  - remove the previous install first, then reinstall. Current test releases use package `com.sts2launcher.overhaul.fork.dev`:
   
   ```bash
-  adb uninstall com.sts2launcher.overhaul.fork
-  adb install -r StS2Launcher-vX.Y.Z.apk
+  adb uninstall com.sts2launcher.overhaul.fork.dev
+  adb install -r StS2Launcher-vX.Y.Z-arm64-v8a.apk
   ```
 - `INSTALL_FAILED_OLDER_SDK`:
   - your device is running an unsupported Android API level.
-- `INSTALL_FAILED_DEXOPT` or immediate crash:
 - `App isn't compatible with your phone`:
-  - make sure you downloaded the `universal` APK, not the `x86_64` emulator-only APK.
+  - make sure you downloaded an APK matching your device ABI. Current public test releases are ARM64-only.
 - `INSTALL_FAILED_DEXOPT` or immediate crash:
   - capture logs with `adb logcat` and open a release issue with stack trace.
 
@@ -323,3 +378,4 @@ This enables the fast multiplayer mode that the mobile client expects.
 This project is licensed under the [MIT License](LICENSE). See [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md) for third-party dependency licenses.
 
 FMOD requires a commercial license if your project generates revenue. Spine Runtimes require a valid Spine Editor license. See the third-party licenses file for details.
+

--- a/docs/android-release-validation.md
+++ b/docs/android-release-validation.md
@@ -1,5 +1,7 @@
 # Android release validation checklist
 
+Current posture: the ARM64 Android path works locally, including Steam download, Pull from Cloud, Push-to-Cloud hardening, Android local save handoff, and game launch. Release validation is now about hardening that baseline on the newest public APK, especially Samsung retests, persisted Steam-session/update UX, confirmed Push overwrite evidence, upgrade install behavior, freshness/cache checks, visual loading-screen regressions, and release artifact hygiene. See [current Android status](current-android-status.md).
+
 Use this checklist after every release run (manual or tag-triggered) to confirm artifact publication before announcing a release.
 
 ## 1) Verify workflow outcome
@@ -43,35 +45,58 @@ Use this checklist after every release run (manual or tag-triggered) to confirm 
 
 1. Open the release page for the tag (for example `v0.2.0`).
 2. Confirm at least one APK asset exists with name pattern:
-   - `StS2Launcher-v<version>.apk`
+   - Current ARM64 releases: `StS2Launcher-v<version>-arm64-v8a.apk`
+   - Older universal releases: `StS2Launcher-v<version>.apk` or `StS2Launcher-v<version>-universal*.apk`
 3. Confirm checksum file exists:
-   - `StS2Launcher-v<version>.apk.sha256`
+   - `StS2Launcher-v<version>-arm64-v8a.apk.sha256`
 4. Confirm the release body includes generated release notes.
+5. Confirm the release notes distinguish the current working ARM64 path from release-candidate status. Do not claim release-ready cloud sync until Pull and Push have both been validated, including no-accidental-upload behavior for Push.
 
-## 4) Optional checksum verification (local)
+## 4) Structural asset verification
+
+Run the release verifier against the exact release tag and asset:
+
+```powershell
+.\scripts\verify-android-release-apk.ps1 `
+  -ReleaseTag "v0.2.184-loading-scale" `
+  -AssetName "StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk" `
+  -Abi arm64-v8a
+```
+
+For manual checksum verification after downloading the `.sha256` sidecar:
 
 ```bash
-sha256sum -c StS2Launcher-v<version>.apk.sha256
+sha256sum -c StS2Launcher-v<version>-arm64-v8a.apk.sha256
 ```
 
 Expected output:
 
 ```text
-StS2Launcher-v<version>.apk: OK
+StS2Launcher-v<version>-arm64-v8a.apk: OK
 ```
 
 ## 5) Install validation on device
 
-```bash
-adb install -r StS2Launcher-v<version>.apk
+```powershell
+.\scripts\install-android-release.ps1 `
+  -ReleaseTag "v0.2.184-loading-scale" `
+  -AssetName "StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk" `
+  -ClearAppData `
+  -Launch `
+  -CaptureDiagnostics
 ```
 
 1. Start app and confirm launcher UI appears.
 2. Confirm no immediate crash on cold start.
+3. Confirm native splash, launcher loading/warmup, and settled launcher surfaces do not clip or distort on the target screen.
+4. Confirm Steam login reaches authentication success or ownership verification.
+5. Confirm game download works when game files are absent.
+6. Confirm Pull from Cloud downloads real Steam Cloud files, writes Android local saves, and the game reads/surfaces the pulled profile.
+7. Confirm Push to Cloud requires confirmation, cancel/no-confirm does not upload, and confirmed Push behavior is explicitly validated or deferred with overwrite-risk rationale.
+8. Confirm locked-screen/focus interruption and upgrade install behavior for every new release candidate before calling it ready.
 
 ## 6) Archive and follow-up
 
 - Record any failures in the release PR or issue tracker.
 - Fix root cause before creating the next tag.
 - Add a short note to `OVERHAUL_STATUS.md` if a process step changes.
-

--- a/docs/android-runtime-findings.md
+++ b/docs/android-runtime-findings.md
@@ -1,10 +1,16 @@
 # Android runtime findings
 
+Current posture: the app works on the validated ARM64 path and is in polish/hardening. Treat this document as runtime findings supporting [current Android status](current-android-status.md), not as a claim that release-candidate validation is complete.
+
 ## Current conclusion
 
 The Android `x86_64` emulator is useful for install, routing, release packaging, and native diagnostic-screen validation, but it is not a reliable target for the Godot/.NET launcher or downloaded game runtime.
 
 Use an `arm64-v8a` Android device/build as the proof target for actual game launch.
+
+The latest published APK has passed GitHub release build and structural asset verification. Local ARM64 validation has now proven the working launcher path through fresh runtime install, Steam game download, Pull from Cloud, Android local save handoff, and game launch with the pulled profile visible in-game. The current public APK also has an ARM64 install/launch visual check for the adaptive launcher/loading-scale work.
+
+This is still a hardening state, not a finished release-candidate signoff. Newest-public-release Pull/Push/game-launch smoke, persisted Steam-session/update UX, Samsung reporter retests, stale assembly cache behavior, and repeated release-readiness coverage remain open validation gates.
 
 ## Evidence so far
 
@@ -43,39 +49,50 @@ Use an `arm64-v8a` Android device/build as the proof target for actual game laun
 - This validates APK installability, ABI routing, package metadata, and native diagnostic UI on a visible emulator.
 - It does not validate Steam login, download, or Godot/.NET launcher runtime.
 - This is expected and intentional.
+- If `sts2_force_godot_x86=1` is used to bypass the fallback, crashes in the forced Godot path are expected diagnostic evidence, not a release blocker by themselves.
 
 ### Android arm64-v8a device
 
 - Before game files are downloaded: show launcher UI.
 - After game files are downloaded: start Godot/game runtime and apply mobile patches.
-- This path still needs runtime proof on real ARM64 hardware.
+- This path now has local ARM64 proof through authenticated game download, Pull from Cloud, Android local save handoff, and normal game launch.
+- Treat the app as working but still under polish/hardening until Push and release-readiness gates are complete.
 
 ## Local validation commands
 
-The current phone release is:
+The current published APK release is:
 
-- Release: `v0.2.88-apk-native-verify`
-- Phone asset: `StS2Launcher-v0.2.88-universal-phone.apk`
-- Release URL: https://github.com/SocialHummingbird/StS2-Launcher-Overhaul/releases/tag/v0.2.88-apk-native-verify
+- Release: `v0.2.184-loading-scale`
+- Asset: `StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk`
+- Release URL: https://github.com/SocialHummingbird/StS2-Launcher-Overhaul/releases/tag/v0.2.184-loading-scale
+- SHA-256: `299f77e9c307b64521ffef73afb890fb2c69bb7a920bf7d24c971cf0b6663f2d`
 
 Before installing, verify the uploaded GitHub release asset itself:
 
 ```powershell
-.\scripts\verify-android-release-apk.ps1
+.\scripts\verify-android-release-apk.ps1 `
+  -ReleaseTag "v0.2.184-loading-scale" `
+  -AssetName "StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk" `
+  -Abi arm64-v8a
 ```
 
 Expected result:
 
 ```text
-Release digest OK: 7ff0e7d03ec49ae079bf52d3f2d6b381cfd4f0e95220eb151cef46d51e848530
-Release APK verification passed: v0.2.88-apk-native-verify/StS2Launcher-v0.2.88-universal-phone.apk
-Verified ABIs: arm64-v8a, x86_64
+Release digest OK: 299f77e9c307b64521ffef73afb890fb2c69bb7a920bf7d24c971cf0b6663f2d
+Release APK verification passed: v0.2.184-loading-scale/StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk
+Verified ABIs: arm64-v8a
 ```
 
 Install the verified release APK to a connected phone and capture diagnostics in one run:
 
 ```powershell
-.\scripts\install-android-release.ps1 -ClearAppData -Launch -CaptureDiagnostics
+.\scripts\install-android-release.ps1 `
+  -ReleaseTag "v0.2.184-loading-scale" `
+  -AssetName "StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk" `
+  -ClearAppData `
+  -Launch `
+  -CaptureDiagnostics
 ```
 
 If the app is already installed and you only need fresh diagnostics:
@@ -86,7 +103,7 @@ If the app is already installed and you only need fresh diagnostics:
 
 The diagnostic capture writes a timestamped `artifacts/android/phone-diagnostics-*` directory with device metadata, full logcat, filtered logcat, package state, and app-private assembly cache listings when `run-as` is available.
 
-For phone installs, use a universal APK when available. ABI-specific APKs are useful for debugging, but the `x86_64` APK is emulator-only and will be incompatible with ARM64 phones.
+For phone installs, use an APK that matches the device ABI. The current public APK is ARM64-only. Older `x86_64` APKs are emulator-only and will be incompatible with ARM64 phones.
 
 Build ABI-specific local artifacts:
 
@@ -114,9 +131,10 @@ The smoke test writes:
 - `artifacts/android/logcat-smoke-*-filtered.txt`
 - `artifacts/android/logcat-smoke-*-full.txt`
 
-## Missing proof
+## Remaining proof
 
-- ARM64 device run from clean app data through Steam auth.
-- ARM64 download of game files.
-- ARM64 launch of downloaded game PCK.
-- Confirmation that Harmony/mobile patches apply successfully on ARM64 without the Android `x86_64` runtime crash signature.
+- Repeat confirmed Push to Cloud behavior on the newest public APK, including Steam Cloud metadata/file mutation after explicit user approval.
+- Repeat cancel/no-confirm Push safety evidence on the newest public APK showing no upload starts without confirmation.
+- Upgrade install evidence showing package `lastUpdateTime` advances and stale app-private assembly cache behavior does not recur.
+- Locked-screen interruption behavior showing Android focus loss does not get misclassified as a game crash.
+- Repeated release-readiness pass covering fresh install, upgrade install, Pull, Push, game launch, and diagnostics.

--- a/docs/current-android-status.md
+++ b/docs/current-android-status.md
@@ -1,0 +1,116 @@
+# Current Android Status
+
+_Last updated: 2026-06-09_
+
+Current device evidence ledgers:
+
+- [android-device-validation-20260608.md](android-device-validation-20260608.md)
+- [android-cloud-save-validation-20260609.md](android-cloud-save-validation-20260609.md)
+- [launcher-loading-screen-staging.md](launcher-loading-screen-staging.md)
+
+## Headline
+
+The app now works on the validated ARM64 Android path, but it is still in polish and hardening rather than release-candidate signoff.
+
+Validated locally on ARM64 hardware:
+
+- Fresh APK/runtime install reaches the launcher.
+- The latest public release APK verifies structurally, installs, launches, and has a captured ARM64 launcher visual check.
+- Public release upgrade compatibility has advanced through `v0.2.184-loading-scale` with `versionCode=218400`; earlier proof showed `v0.2.175-refactor-apk` to `v0.2.177-login-a8729d6` preserving install state.
+- Locked-screen interruption returns to the app after manual unlock without app-specific crash markers.
+- Steam login and game depot download complete.
+- Pull from Cloud downloads real Steam Cloud files.
+- Push to Cloud completes on the local hardening build without post-Push process death.
+- Pull after Push downloads and writes the pushed cloud state back to Android local storage.
+- Android local save handoff works.
+- The downloaded game launches and shows the pulled `Profile 1` in-game.
+- Force-stop/relaunch returns to the launcher with saved Steam credentials available.
+
+## Latest hardening evidence
+
+Latest public release evidence:
+
+```text
+release=v0.2.184-loading-scale
+asset=StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk
+sha256=299f77e9c307b64521ffef73afb890fb2c69bb7a920bf7d24c971cf0b6663f2d
+package=com.sts2launcher.overhaul.fork.dev
+versionName=0.2.184-loading-scale
+versionCode=218400
+upgradeBaseline=v0.2.183-login-hardening / versionCode=218300
+```
+
+Latest device evidence folders:
+
+- `artifacts/android/github-release-v0.2.184-loading-scale`
+- `artifacts/android/phone-diagnostics-20260609-204439`
+- `artifacts/android/loading-scale-release-visual-20260609`
+- `artifacts/android/physical-login-RFCY70XQE7F-logcat.txt`
+- `artifacts/android/phone-diagnostics-20260608-220359`
+- `artifacts/android/lock-unlock-validation-20260608-215548`
+- `artifacts/android/local-pull-smoke-20260608-221143`
+- `artifacts/android/local-start-game-dpad-20260608`
+- `artifacts/android/local-game-profile-center-20260608`
+- `artifacts/android/local-restart-diagnostics-20260608`
+
+The latest local hardening build proved that the phone was running the freshly installed runtime and managed assemblies:
+
+```text
+versionName=0.2.0-local-hardening-freshness2-20260608
+versionCode=2260810
+schema=22
+storedSchema=22
+storedVersionCode=2260810
+arch=arm64
+sts2MobileBytes=622080
+```
+
+The startup freshness probe and assembly cache diagnostics now report the installed package/version/schema, cache presence, `STS2Mobile.dll` size, and expected source/byte counts for required assemblies. This addresses the previous ambiguity where the phone could appear to be running a newer APK while still using stale cached managed assemblies.
+
+## Cloud-save posture
+
+Pull from Cloud and Push to Cloud are now validated end to end on the local ARM64 hardening path. Steam Cloud files were enumerated/downloaded, Android local save files were written, Push uploaded/flushed the local save batch without process death, and Pull after Push wrote the cloud state back into Android app storage.
+
+- The Push confirmation gate appears before upload.
+- Direct Cancel returns to the launcher without upload.
+- Back/no-confirm dismissal returns without upload.
+- The latest warning text names Steam Cloud overwrite risk in code and documentation.
+- Confirmed Push can overwrite real Steam Cloud state; keep it treated as an explicit destructive action.
+- The 2026-06-09 Push crash was fixed by replacing Android native `SHA1.HashData` in the cloud upload file-hash path with managed SHA-1.
+- Push evidence: `artifacts/android/push-managedsha1-observation-20260609-1`.
+- Current-build manual Push evidence: `artifacts/android/push-clean3-observation-20260609-1`.
+- Pull-after-Push evidence: `artifacts/android/pull-after-push-observation-20260609-1`.
+- Preferred local evidence summaries: `summary-scrubbed.md` inside each 2026-06-09 Push/Pull artifact folder.
+- Current launcher Push/Pull UI status text now names direction explicitly: Push makes Steam Cloud reflect Android local saves, and Pull makes Android local saves reflect Steam Cloud.
+- Push confirmation now tells testers to Pull first and verify Android local saves exist before pushing, because Push can overwrite Steam Cloud state.
+- Save discovery now skips app runtime/cache trees such as `.godot`, `cache`, `game`, and `tmp` during fallback enumeration so cloud-save diagnostics stay focused on save candidates.
+
+## Remaining release-readiness blockers
+
+- Re-run full login/Pull/Push confirmation/cancel/game-launch smoke on the clean public `v0.2.184-loading-scale` release-facing build.
+- Keep Push treated as destructive even though local clean3 manual Push confirmation is validated; newest release-facing smoke still needs to confirm the same behavior on the public APK.
+- Repeated local stale assembly cache/freshness checks across in-place local upgrade once signing continuity is restored.
+- Repeat release asset hygiene on every new release: signer, package name, versionCode monotonicity, checksums, structural verifier, and GitHub release notes.
+- Further diagnostics polish so normal successful startup/cloud-save behavior is not hidden by remaining low-value platform logs.
+- Improve persisted Steam session/update UX so game update checks do not appear to require unnecessary re-login when a saved session is still valid.
+
+## Device-independent polish completed after baseline proof
+
+- Local smoke/login/verification scripts now select APKs by parsed package metadata and versionCode, with ABI/package compatibility checks where applicable, instead of relying only on file write time.
+- Push-to-Cloud warning text now names Steam Cloud explicitly, calls out overwrite risk before upload, and directs testers to Pull first and verify Android local saves exist before pushing.
+- Manual cloud-sync start/complete/failure status updates now keep the launcher header aligned with the operation result instead of leaving stale generic status text behind.
+- Recovery cleanup logging now describes normal post-startup cleanup as success-path UI cleanup.
+- Diagnostics filters retain startup freshness, assembly cache, expectedSource/expectedBytes, cloud sync, and crash evidence while reducing broad log noise.
+- Native splash now uses the scalable launcher vector icon, shader-warmup/loading panel sizing is short-edge aware, and startup status text is safe-margin anchored for short/wide Android screens.
+
+## Static upgrade/cache freshness review
+
+The Android activity cache path has a usable static evidence chain for upgrade/freshness diagnosis:
+
+- Startup freshness logs package, versionName/versionCode, schema, stored schema, stored versionCode, stored package, runtime arch, cache existence, and `STS2Mobile.dll` bytes.
+- Assembly setup logs `cache-hit` versus full recopy and emits `expectedSource`/`expectedBytes` for required managed assemblies.
+- Public package runtime proof exists for `v0.2.175 -> v0.2.177`; the remaining gap is local-package in-place upgrade proof after `.local` signing continuity is restored.
+
+## Emulator limitation
+
+ARM64 hardware is the proof target for Steam login, download, cloud sync, and game launch. Android `x86_64` emulator coverage is useful for install/routing/native-fallback diagnostics only; forcing Godot on `x86_64` remains a crash-prone diagnostic path, not release proof.

--- a/docs/reddit-announcement-prep-20260609.md
+++ b/docs/reddit-announcement-prep-20260609.md
@@ -1,0 +1,67 @@
+# Reddit announcement prep - 2026-06-09
+
+## Current public claim
+
+StS2 Launcher now works on the validated ARM64 Android path: install, Steam login, game download, Pull from Cloud, local hardening Push to Cloud, Pull-after-Push, local save handoff, and game launch/profile visibility have been validated. The newest public release asset is published, structurally verified, and installed/launched on ARM64 hardware, but full newest-public-release Pull/Push/game-launch smoke is still pending before release-candidate signoff.
+
+## Public release to link
+
+- Repository: https://github.com/SocialHummingbird/StS2-Launcher-Overhaul
+- Release: https://github.com/SocialHummingbird/StS2-Launcher-Overhaul/releases/tag/v0.2.184-loading-scale
+- APK: `StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk`
+- Package: `com.sts2launcher.overhaul.fork.dev`
+- Version: `0.2.184-loading-scale` / `versionCode=218400`
+- SHA-256: `299f77e9c307b64521ffef73afb890fb2c69bb7a920bf7d24c971cf0b6663f2d`
+- Target: ARM64 Android phones only for real validation.
+
+## Posting constraints checked
+
+- Direct `r/slaythespire` rules access was attempted on 2026-06-09, but Reddit returned network-security/403 blocks from this environment. Treat subreddit-specific approval as unverified until checked from a logged-in browser or by modmail.
+- Reddit's platform rules require community-rule compliance, authentic participation, no spam/disruptive behavior, no deception/impersonation, and respect for privacy. Source: https://redditinc.com/policies/reddit-rules
+- Reddit Help says promotional content is not inherently spam, but some communities disallow promotional content and others use a 10% self-promotion convention. It also lists repeated same/similar posts, unrelated link-farmed posts, disguised redirects, harmful links, and promotional bots as spam examples. Source: https://support.reddithelp.com/hc/en-us/articles/28012014962580-How-do-I-keep-spam-out-of-my-community
+- The announcement should disclose affiliation, avoid APK-only promotion, avoid reposting, and avoid asking users to post private data.
+- If using a Slay the Spire 2-specific community, repeat the same mod-rule check before posting because subreddit rules can change.
+
+## Must-say caveats
+
+- Unofficial community project; Mega Crit is not involved.
+- Requires a valid Steam account that owns Slay the Spire 2.
+- No game assets are bundled or redistributed.
+- ARM64 Android hardware is the support target; x86_64 emulator behavior is diagnostic-only.
+- Pull from Cloud before Push to Cloud.
+- Push to Cloud can overwrite Steam Cloud state. Only use it after verifying Android local saves are the intended state.
+- Do not share credentials, guard codes, refresh tokens, private save data, or unsanitized logs in public.
+- This is working, but still in polish/hardening rather than release-candidate signoff.
+
+## Suggested Reddit title
+
+StS2 Launcher now runs Slay the Spire 2 on ARM64 Android - working, but still in polish/hardening
+
+## Suggested Reddit body
+
+I have been working on an unofficial Android launcher for Slay the Spire 2: https://github.com/SocialHummingbird/StS2-Launcher-Overhaul
+
+The current ARM64 Android path now works in testing: the app installs, authenticates with Steam, downloads the game files from Steam, pulls Steam Cloud saves into Android local storage, launches the game, and shows the pulled profile in-game. Push to Cloud has also been validated on the local hardening build and the fix is included in the latest public APK. Recent public builds also include Samsung-layout reachability fixes, Steam login crash-boundary hardening, and adaptive native splash/loading-screen scaling.
+
+This is not a finished release-candidate yet. It is in the polish/hardening phase, and I am looking for technically comfortable testers who understand the risks.
+
+Important caveats:
+
+- You need a Steam account that owns Slay the Spire 2.
+- No game assets are included in the repo or APK.
+- Current real target is ARM64 Android phones, not x86_64 emulators.
+- Pull from Cloud before using Push to Cloud.
+- Push to Cloud can overwrite Steam Cloud saves, so only use it after verifying the Android local saves are the state you want in Steam Cloud.
+- Do not post credentials, guard codes, tokens, private save contents, or full unsanitized logs publicly.
+
+Latest public APK:
+https://github.com/SocialHummingbird/StS2-Launcher-Overhaul/releases/tag/v0.2.184-loading-scale
+
+If you try it, the most useful feedback is device model, Android version, whether install/login/download/Pull/game launch worked, and any scrubbed crash log snippets. Please keep reports sanitized.
+
+## Recommended posting approach
+
+1. Prefer a text post linking to the GitHub repository and release, not a direct APK-only post.
+2. Put the unofficial/no-assets/Steam-ownership caveats near the top.
+3. Make the testing request explicit and avoid marketing language.
+4. If posting to a subreddit with unclear self-promotion rules, send modmail first with the title/body above.

--- a/docs/runbook-android-validation.md
+++ b/docs/runbook-android-validation.md
@@ -1,10 +1,13 @@
 # Android Validation Runbook
 
+Current posture: validate regressions against the working ARM64 baseline, then collect evidence for remaining hardening gates. The baseline is fresh install, Steam download, Pull from Cloud, Push hardening, Android local save handoff, game launch, and adaptive launcher/loading screen behavior. See [current Android status](current-android-status.md).
+
 This runbook is used for manual verification of startup and reliability changes where full automation is not available.
 
 ## Scope
 
-- New startup patches (platform, locale, optional patch groups)
+- New startup patches, platform behavior, locale behavior, and optional patch groups
+- Steam login/authentication and ownership checks
 - Cloud sync lifecycle behavior changes
 - UI/layout and launcher interaction updates
 - Multiplayer/cloud-dependent changes
@@ -21,22 +24,30 @@ This runbook is used for manual verification of startup and reliability changes 
 Run at least one device from each row for patch-level changes:
 
 - Pixel / Android 16 + default locale
-- Samsung Galaxy S25/S26 class + non-US locale (Korean or locale extension heavy)
+- Samsung Galaxy S25/S26 class + non-US locale, such as Korean or locale-extension-heavy settings
 - Samsung Fold / One UI with locale extensions enabled
-- Mid-tier Android 12–13 fallback device (smoke coverage for older API)
+- Mid-tier Android 12-13 fallback device, for smoke coverage on older API levels
 
 ## Standard Procedure
 
-1. Verify the current published phone APK:
+1. Verify the current published ARM64 APK:
 
 ```powershell
-.\scripts\verify-android-release-apk.ps1
+.\scripts\verify-android-release-apk.ps1 `
+  -ReleaseTag "v0.2.184-loading-scale" `
+  -AssetName "StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk" `
+  -Abi arm64-v8a
 ```
 
-2. Install/update the verified APK on target device. For the current published phone release:
+2. Install/update the verified APK on target device. For the current published ARM64 release:
 
 ```powershell
-.\scripts\install-android-release.ps1 -ClearAppData -Launch -CaptureDiagnostics
+.\scripts\install-android-release.ps1 `
+  -ReleaseTag "v0.2.184-loading-scale" `
+  -AssetName "StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk" `
+  -ClearAppData `
+  -Launch `
+  -CaptureDiagnostics
 ```
 
 3. If the APK is already installed and only runtime evidence is needed:
@@ -47,33 +58,43 @@ Run at least one device from each row for patch-level changes:
 
 4. Capture baseline metadata.
 
-The scripts above write the metadata to `artifacts/android/phone-diagnostics-*`; if collecting manually, include:
-   - Device model
-   - Android version / security patch
-   - Locale + region settings
-   - App branch + commit hash
+The scripts above write metadata to `artifacts/android/phone-diagnostics-*`. If collecting manually, include:
+
+- Device model
+- Android version / security patch
+- ABI
+- Locale + region settings
+- App version, release tag, APK asset, branch, and commit hash
+- Clean install or update install
+
 5. Start log capture if not using the scripts:
 
 ```bash
 adb logcat > sts2launcher-<device>-<date>.log
 ```
 
-6. Repro the target flow once only (avoid duplicate noise):
-   - Launch app from home screen
-   - Open launcher
-   - Trigger patch area (where applicable): cloud sync, locale switch, multiplayer join, etc.
+6. Repro the target flow once only to avoid duplicate noise:
+
+- Launch app from home screen
+- Open launcher
+- Trigger patch area where applicable: Steam login, cloud sync, locale switch, multiplayer join, download, or game launch
+
 7. Stop log capture and collect:
-   - First 300 lines around first failure
-   - Final 120 lines of session
-   - Any black-screen/retry overlay screenshots
+
+- First 300 lines around first failure
+- Final 120 lines of session
+- Any black-screen, retry overlay, or login failure screenshots
 
 ## Pass/Fail Checklist
 
 ### Startup path
 
 - [ ] Launcher opens without immediate dev/command overlay
+- [ ] Native splash uses the launcher icon and does not stretch/distort on the target display
+- [ ] Loading/warmup/startup status surfaces fit inside safe screen margins
 - [ ] No `.NET assemblies not found` alert
 - [ ] `Assembly cache diagnostics` shows `arm64` and required DLLs present on ARM64 phone
+- [ ] Steam login reaches authentication success or ownership verification
 - [ ] Game logo/menu appears within expected window for device class
 - [ ] No repeated `NullReferenceException` or locale parsing loop
 - [ ] No crash stack repeatedly referencing startup patch entry points
@@ -83,28 +104,45 @@ adb logcat > sts2launcher-<device>-<date>.log
 - [ ] Initial sync does not stall indefinitely
 - [ ] Large cloud backlog remains bounded and progresses/logs progress
 - [ ] No repeated write-queue timeouts on background/resume
+- [ ] Pull from Cloud downloads real Steam Cloud files and writes Android local saves
+- [ ] Game startup reads the same Android local save paths populated by Pull
+- [ ] Push to Cloud shows confirmation before upload
+- [ ] Cancel/no-confirm Push path does not start upload
+- [ ] Confirmed Push is validated only when it is safe to mutate Steam Cloud state, or explicitly deferred with risk noted
 
 ### UI/layout path
 
 - [ ] Main layout loads without `NullReferenceException` spikes in same frame
 - [ ] Menu/buttons remain interactive in initial scene
 
+### Release hardening path
+
+- [ ] Fresh install proves runtime freshness with current assembly schema logs
+- [ ] Upgrade install advances package update time and does not reuse stale managed assemblies
+- [ ] Successful game startup hides launcher recovery controls quickly
+- [ ] Locked-screen or Android focus interruption is not misreported as a game crash
+- [ ] Normal diagnostics avoid missing-path log floods; verbose save diagnostics remain opt-in
+
 ## Evidence format for PR comments/issues
 
-- Include:
-  - Device matrix row used
-  - Repro steps and whether a clean install was used
-  - Log excerpt block names:
-    - `PatchHelper`
-    - `Loc` / `CultureInfo`
-    - `FontSubstitution`
-    - `Cloud`
-    - `Lifecycle`
+Include:
+
+- Device matrix row used
+- Repro steps and whether a clean install was used
+- Release tag, APK asset, package name, and ABI
+- Log excerpt block names:
+  - `PatchHelper`
+  - `Steam` / `SteamKit`
+  - `Loc` / `CultureInfo`
+  - `FontSubstitution`
+  - `Cloud`
+  - `Lifecycle`
 - Timestamped failure window and symptom duration
 
 ## Escalation
 
 If the same fatal signal repeats on the same device class twice in the same runbook session:
+
 - Open a new issue using the bug template
 - Link this runbook and attach logs
 - Note the last successful checklist entry before regression


### PR DESCRIPTION
Updates the GitHub-facing Android release/status documentation for the current public APK.\n\nIncludes:\n- README current status moved to v0.2.184-loading-scale;\n- release verifier/install examples updated to the current APK;\n- stale v0.2.178/v0.2.180/v0.2.182 public guidance removed;\n- current known limitations documented, including Samsung retests, persisted Steam-session/update UX, and newest-public-release Pull/Push/game-launch smoke;\n- Reddit prep and validation runbooks aligned to v0.2.184.\n\nRelease evidence:\n- v0.2.184-loading-scale published;\n- APK SHA-256: 299f77e9c307b64521ffef73afb890fb2c69bb7a920bf7d24c971cf0b6663f2d;\n- release APK structurally verified;\n- published APK installed/launched on connected ARM64 Android device.