### PR TITLE
Improve tester onboarding docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/crash_startup.md
+++ b/.github/ISSUE_TEMPLATE/crash_startup.md
@@ -1,0 +1,62 @@
+---
+name: Crash or startup problem
+about: Report an app crash, hang, black screen, NativeFallback route, or very slow startup
+title: "[CRASH] "
+labels: ["bug", "needs-triage", "category: reliability"]
+assignees: []
+---
+
+## What happened
+
+Describe the crash, hang, black screen, fallback screen, or slow startup.
+
+## When it happened
+
+- [ ] Immediately after opening the app
+- [ ] During Steam login
+- [ ] During game download/update
+- [ ] After pressing Start Game
+- [ ] After selecting a branch
+- [ ] After enabling mods
+- [ ] After returning from the game to the launcher
+
+## Environment
+
+- Device model:
+- Android version:
+- Vendor skin/version, for example One UI:
+- Device ABI:
+- APK release tag:
+- APK filename:
+- Package name shown by Android, if known:
+- Clean install or update install:
+
+## Timing
+
+- App icon tap to launcher visible:
+- Start Game tap to game main menu:
+- Last visible screen before failure:
+
+## Evidence
+
+- Screenshot or screen recording:
+- Focused logcat attached:
+- Any generated diagnostics file attached:
+
+Useful logcat search terms:
+
+```text
+AndroidRuntime
+FATAL EXCEPTION
+Godot
+STS2Mobile
+PatchHelper
+NativeFallback
+SteamKit
+Workshop
+Mods
+```
+
+## Safety check
+
+- [ ] I removed Steam credentials, Steam Guard codes, tokens, and private account details from logs.

--- a/.github/ISSUE_TEMPLATE/device_compatibility.md
+++ b/.github/ISSUE_TEMPLATE/device_compatibility.md
@@ -1,0 +1,50 @@
+---
+name: Device compatibility report
+about: Share whether the latest APK works on your Android device
+title: "[DEVICE] "
+labels: ["needs-triage", "category: reliability"]
+assignees: []
+---
+
+## Device
+
+- Device model:
+- Android version:
+- Vendor skin/version, for example One UI:
+- Device ABI:
+- Display size setting:
+- Font size setting:
+- APK release tag:
+- APK filename:
+- Clean install or update install:
+
+## Result
+
+- [ ] App opens to launcher
+- [ ] Steam login works
+- [ ] Game download/update works
+- [ ] Pull from Steam Cloud works
+- [ ] Public/default branch launches
+- [ ] Public-beta/core-release branch launches
+- [ ] Mods section appears
+- [ ] Vanilla launch works
+- [ ] Modded launch works
+- [ ] Save/profile appears in-game
+
+## Performance
+
+- App icon tap to launcher visible:
+- Start Game tap to game main menu:
+- Any long pause, black screen, or crash:
+
+## Notes
+
+Describe anything unusual: keyboard problems, password-manager behavior, clipped buttons, missing controls, unreadable text, or thermal/performance issues.
+
+## Evidence
+
+Attach screenshots for UI/layout reports and focused logs for crashes.
+
+## Safety check
+
+- [ ] I removed Steam credentials, Steam Guard codes, tokens, and private account details from logs.

--- a/.github/ISSUE_TEMPLATE/download_branch.md
+++ b/.github/ISSUE_TEMPLATE/download_branch.md
@@ -1,0 +1,64 @@
+---
+name: Game download or branch issue
+about: Report public/default, public-beta, core-release, or other Steam branch download and launch behavior
+title: "[BRANCH] "
+labels: ["bug", "needs-triage", "category: reliability"]
+assignees: []
+---
+
+## Summary
+
+Describe the game download, update, branch selection, or launch issue.
+
+## Branch tested
+
+- [ ] Public/default
+- [ ] Public-beta
+- [ ] Core-release
+- [ ] Other:
+
+## Environment
+
+- Device model:
+- Android version:
+- APK release tag:
+- APK filename:
+- Clean install or update install:
+- Steam account owns Slay the Spire 2:
+
+## Result
+
+- [ ] Branch appeared in the launcher
+- [ ] Branch downloaded successfully
+- [ ] Branch was blocked clearly
+- [ ] Branch launched successfully
+- [ ] Launcher showed NativeFallback
+- [ ] Game looked like the wrong branch
+- [ ] Missing or mixed assets appeared
+
+## Evidence
+
+Paste any visible diagnostics:
+
+```text
+Selected game branch:
+Selected game PCK path:
+Selected game PCK hash:
+Runtime pack path:
+Runtime pack hash:
+Active sts2.dll hash:
+Runtime cache marker:
+Patch validation marker:
+```
+
+Attach focused logs or screenshots showing the selected branch and failure.
+
+## Steam Cloud safety
+
+- Did Pull from Cloud run:
+- Did Push to Cloud run:
+- If Push ran, why was it safe:
+
+## Safety check
+
+- [ ] I removed Steam credentials, Steam Guard codes, tokens, and private account details from logs.

--- a/.github/ISSUE_TEMPLATE/mods_save_merger.md
+++ b/.github/ISSUE_TEMPLATE/mods_save_merger.md
@@ -1,0 +1,83 @@
+---
+name: Mods or save-merger test
+about: Report Workshop/mod loading, mod selection, manual import, or Vanilla and Modded Saves Merger behavior
+title: "[MODS] "
+labels: ["bug", "needs-triage", "category: reliability"]
+assignees: []
+---
+
+## Summary
+
+Describe the mod loading or save-merger result.
+
+## Test type
+
+- [ ] Workshop sync/discovery
+- [ ] Manual import
+- [ ] Vanilla launch with mods disabled
+- [ ] Modded launch with selected mods
+- [ ] Vanilla and Modded Saves Merger
+- [ ] Save compatibility
+
+## Environment
+
+- Device model:
+- Android version:
+- APK release tag:
+- APK filename:
+- Selected game branch:
+- Clean install or update install:
+
+## Mods
+
+List every selected mod in launch order if known:
+
+```text
+
+```
+
+For each important mod, note:
+
+- Workshop item ID:
+- Source: Workshop sync or manual import
+- Files present, for example `.dll`, `.json`, `.pck`:
+- Enabled or disabled:
+
+## Save behavior
+
+- Existing vanilla save present before test:
+- Existing modded save present before test:
+- Pull from Steam Cloud run before test:
+- Push to Steam Cloud run during test:
+- Save became visible in-game:
+- Save loaded successfully:
+
+## Result
+
+- [ ] Game reached main menu
+- [ ] Game loaded selected mods
+- [ ] Game launched vanilla with zero mods
+- [ ] Save merger made existing saves usable
+- [ ] Save merger did not work
+- [ ] App crashed or hung
+
+## Evidence
+
+Attach screenshots or focused logs. Useful logcat search terms:
+
+```text
+Workshop
+Mods
+SavesMerger
+BaseLib
+Quick Restart
+Loaded
+PatchHelper
+AndroidRuntime
+FATAL EXCEPTION
+```
+
+## Safety check
+
+- [ ] I did not run Push to Cloud unless I intentionally wanted to upload the tested Android save state.
+- [ ] I removed Steam credentials, tokens, and private account details from logs.

--- a/.github/ISSUE_TEMPLATE/steam_cloud_login.md
+++ b/.github/ISSUE_TEMPLATE/steam_cloud_login.md
@@ -1,0 +1,66 @@
+---
+name: Steam login or Cloud problem
+about: Report Steam authentication, ownership, Pull from Cloud, or guarded Push behavior
+title: "[STEAM/CLOUD] "
+labels: ["bug", "needs-triage", "category: reliability"]
+assignees: []
+---
+
+## Summary
+
+Describe the Steam login, ownership, Pull, or Push problem.
+
+## Area
+
+- [ ] Steam login
+- [ ] Steam Guard / 2FA
+- [ ] Ownership check
+- [ ] Pull from Steam Cloud to Android
+- [ ] Push from Android to Steam Cloud
+- [ ] Cloud conflict or stale-save warning
+- [ ] Push was blocked by safety gates
+
+## Environment
+
+- Device model:
+- Android version:
+- APK release tag:
+- APK filename:
+- Clean install or update install:
+- Selected game branch:
+- Mods enabled:
+
+## What you did
+
+1.
+2.
+3.
+
+## Result
+
+- Expected:
+- Actual:
+- Did Steam Guard appear:
+- Did Pull from Cloud run:
+- Did Push to Cloud run:
+- Did the launcher ask for overwrite confirmation:
+
+## Evidence
+
+Attach focused logs or screenshots. Do not attach credentials, Steam Guard codes, tokens, or full unsanitized logs.
+
+Useful logcat search terms:
+
+```text
+Steam
+SteamKit
+Cloud
+Pull
+Push
+AndroidRuntime
+FATAL EXCEPTION
+```
+
+## Safety check
+
+- [ ] I did not include Steam credentials, Steam Guard codes, refresh tokens, or unsanitized account details.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The goal is a **drastic architecture and reliability overhaul** that is harder t
 - Device log checklist: [docs/device-log-checklist.md](docs/device-log-checklist.md)
 - Android runtime findings: [docs/android-runtime-findings.md](docs/android-runtime-findings.md)
 - Current Android status: [docs/current-android-status.md](docs/current-android-status.md)
+- Testing needed: [docs/testing-needed.md](docs/testing-needed.md)
 
 ### Suggested working remotes
 
@@ -36,17 +37,49 @@ An Android launcher for Slay the Spire 2, built on a custom Godot 4.5.1 engine w
 
 ## Current Status
 
-**Working ARM64 Android baseline:** the launcher now installs, starts, authenticates with Steam, downloads game files, pulls Steam Cloud saves into Android local app storage, pushes Android saves back to Steam Cloud on the local hardening build, and launches the game with the pulled profile visible in-game.
+**Current state:** StS2 Mobile is playable on tested ARM64 Android hardware, but it is still a prerelease community launcher. The focus is now stability, loading speed, cleaner onboarding, branch switching, Steam Cloud safety, and experimental Workshop/mod support.
 
-This is still a polish and hardening phase, not release-candidate signoff. The active work is focused on broader Samsung/One UI retesting, persisted Steam-session/update UX, richer loading/progress surfaces, quieter diagnostics, and repeatable release asset hygiene.
+Latest published APK prerelease: [v0.2.335-mod-selector-deps-cloud-marker-debug](https://github.com/SocialHummingbird/StS2-Launcher-Overhaul/releases/tag/v0.2.335-mod-selector-deps-cloud-marker-debug)
 
-- Latest published APK release: `v0.2.184-loading-scale`
-- Current APK asset: `StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk`
-- Package name: `com.sts2launcher.overhaul.fork.dev`
-- Release asset SHA-256: `299f77e9c307b64521ffef73afb890fb2c69bb7a920bf7d24c971cf0b6663f2d`
-- Latest verified public release: `0.2.184-loading-scale` / `versionCode=218400`
-- Validated locally/publicly: fresh APK/runtime install, public `v0.2.183 -> v0.2.184` update-compatible release build, launcher startup visual check on ARM64 hardware, Steam login to Steam Guard on public `v0.2.183`, Steam game download, Pull from Cloud, Push to Cloud, Pull-after-Push round trip, Android local save handoff, game launch/profile visibility, and restart-to-launcher behavior on ARM64 hardware.
-- Still hardening: Samsung A53/S25+/S24 Ultra reporter retests, repeated public-release Pull/Push/game-launch smoke on the newest APK, persisted Steam session/update UX, richer launch progress UI, diagnostics polish, and release-candidate signoff.
+- APK asset: `StS2Launcher-v0.2.335-mod-selector-deps-cloud-marker-debug-arm64-v8a.apk`
+- Package name: `com.sts2launcher.overhaul.fork.local`
+- Version code: `335000`
+- SHA-256: `46799153565feb414a702d590e15cc29bea2cfb5437eb4a11fa5606587db2ac1`
+- Signing channel: local debug/test channel
+
+What currently works on tested ARM64 hardware:
+
+- Steam login reaches Steam Guard/authentication flow.
+- Game files can be downloaded from Steam for owned accounts.
+- Public/default game launch has ARM64 evidence.
+- Public-beta branch launch has ARM64 evidence with matched beta PCK and matched beta runtime pack.
+- Steam Cloud Pull into Android local app storage has been validated.
+- Steam Cloud Push is intentionally guarded and is not automatic.
+- The launcher has a first-class Mods section on the main play screen.
+- Workshop/staged mods can be selected, disabled, and launched through the Android runtime mod-loader path.
+- `BaseLib`, `Quick Restart`, and manually imported `Vanilla and Modded Saves Merger` have reached the game main menu in ARM64 validation.
+
+Experimental or still hardening:
+
+- Workshop/mod support is functional but not finished. Steam discovery can stage some subscribed mods, but items exposed only as legacy UGC handles may still need manual import.
+- `Vanilla and Modded Saves Merger` is the most important current mod validation target. It has manual-import launch evidence, but broader save-merge compatibility still needs tester reports.
+- Branch switching is implemented, but beta/password/private branch behavior and save compatibility across branches still need more device evidence.
+- Samsung/One UI layouts and login behavior need more current-version reports from affected users.
+- Startup/loading speed and diagnostics are active refactor targets.
+
+Steam Cloud safety:
+
+- Pull from Steam Cloud is the preferred first action.
+- Push to Steam Cloud is never run automatically.
+- Manual Push is gated because it can overwrite Steam Cloud state.
+- Push remains locked in active modded-save risk states until the launcher has enough evidence that the local save state is safe.
+
+How to help:
+
+- Download the latest APK from [Releases](https://github.com/SocialHummingbird/StS2-Launcher-Overhaul/releases).
+- Read [Testing needed](docs/testing-needed.md) before filing results.
+- Use the focused GitHub issue templates for crashes, Steam Cloud, branch/download issues, mods/save-merger testing, or device compatibility reports.
+
 - Emulator limitation: Android `x86_64` is fallback/diagnostic coverage only. ARM64 hardware remains the proof target.
 
 See [docs/current-android-status.md](docs/current-android-status.md) for the current evidence and remaining blockers.
@@ -54,19 +87,21 @@ See [docs/current-android-status.md](docs/current-android-status.md) for the cur
 ## Features
 
 - **Steam authentication**  
-  Login via SteamKit2 with Steam Guard 2FA support. ARM64 device validation has progressed through authenticated download, cloud pull, local hardening Push, and game launch; release hardening is still ongoing.
+  Login via SteamKit2 with Steam Guard 2FA support. Android now uses an integrated in-app native Steam credential panel with real username/password fields, Android credential-provider hints, accessible field labels, inline status/error guidance, keyboard-safe scrollable layout, and stacked full-width touch controls where supported. The launcher does not store or inject Steam passwords, and native username/password fields are cleared after submit/cancel/expiry. ARM64 device validation has progressed through authenticated download, cloud pull, local hardening Push, and game launch; password-manager suggestion behavior in the native panel still needs broader device reports.
 - **Game file download**  
-  Depot download directly from Steam, with update checking.
+  Depot download directly from Steam, with update checking, an ARM64-validated responsive progress screen, Steam branch/version dropdown selection, a non-mutating `Refresh Game Versions` action that reads account-visible Steam app-info branch metadata, and side-by-side cached installs for non-public branches. The portal explicitly separates local version download/update actions from Steam Cloud save actions and collapses verbose version details on compact screens. Beta/version support is currently a hardening feature: dropdown labels stay concise but can show ready/build/password/unavailable badges, selected-version helper text surfaces availability/password/build metadata where Steam exposes it, known unavailable branches are blocked before game-version download/update attempts, `public-beta` has local ARM64 launch proof from its side-by-side cache, and Steam beta password entry is not implemented.
 - **Cloud saves**  
-  Steam cloud sync via SteamKit2's CCloud API, with timestamp-aware conflict resolution and non-blocking background uploads. Pull from Cloud, Push to Cloud, and Pull-after-Push round trip are validated on ARM64 local hardening builds. Push remains an explicit overwrite-risk action because it can replace Steam Cloud state.
+  Steam cloud sync via SteamKit2's CCloud API, with timestamp-aware conflict resolution and non-blocking background uploads. Pull from Cloud, Push to Cloud, and Pull-after-Push round trip are validated on ARM64 local hardening builds. The portal labels Pull as Steam Cloud to Android and Push as Android saves to Steam Cloud, places Pull before Push so the safer baseline action is visually first, keeps those primary cloud actions above lower-frequency cloud options, and collapses cloud-safety guidance/options on compact screens to reduce clutter. Push remains an explicit overwrite-risk action because it can replace Steam Cloud state, requires an overwrite confirmation arming tap before the final confirmation, shows an armed overwrite warning before the final confirmation, and now gates manual Push on current-version Pull evidence plus Android local save evidence before upload. Branch-switch Push adds stricter selected-version Pull/local-save/backup evidence gates.
+- **Steam Workshop mods**  
+  Subscribed Workshop mods can be synced into app-private Android storage and loaded by the runtime mod-loader patch. Current ARM64 evidence covers public-beta, core-release, and public-after-beta branch switching with matched selected PCK/runtime evidence; `BaseLib` and `Quick Restart` are staged and scanned from Workshop storage. The previous BaseLib initializer hard failure is handled by an Android compatibility filter that skips known incompatible BaseLib patch classes, so those skipped BaseLib features still need follow-up. Workshop sync and clear do not run Steam Cloud Push, and manual Push is locked while active staged Workshop PCK mods are present. The launcher now has a first-class Mods section on the main play screen with active-mod status, unsupported-item attention text, manual import guidance, and Workshop sync/clear actions.
 - **Mobile adaptation**  
-  Touch input, UI scaling, layout adjustments, and app lifecycle handling via Harmony runtime patches.
+  Touch input, short-edge-aware launcher scaling, responsive ready/download/login layouts, larger touch-first action targets, task-led primary action wording, consistent `Start Game` primary CTA, high-contrast rounded actions, a branded atmospheric backdrop, mobile-first compact panel sizing, dynamic compact content width, reduced compact header chrome, compact section headers, compact button labels, a phase-labeled status-led launcher portal with a structured phase chip, error-first guided next-action label, and compact vertical next-step hero, collapsible safe first-run guidance on compact screens, titled Steam sign-in/install/play-sync sections, hidden diagnostics by default, and app lifecycle handling via Harmony runtime patches.
 - **LAN multiplayer**  
   UDP broadcast discovery and manual IP join.
 - **Shader warmup**  
   Vulkan pipeline cache persistence and canvas ubershader support to eliminate first-encounter stutters.
 - **Credential security**  
-  Steam refresh tokens encrypted at rest via Android Keystore (AES-256-GCM, hardware-backed TEE).
+  Steam refresh tokens encrypted at rest via Android Keystore (AES-256-GCM, hardware-backed TEE). Steam passwords are not stored or injected by the launcher, and SteamKit debug logs are disabled by default; when explicitly enabled for diagnostics, they are sanitized before entering launcher diagnostics.
 
 ## How It Works
 
@@ -214,13 +249,13 @@ Current published APK release:
 
 ```powershell
 .\scripts\verify-android-release-apk.ps1 `
-  -ReleaseTag "v0.2.184-loading-scale" `
-  -AssetName "StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk" `
+  -ReleaseTag "v0.2.335-mod-selector-deps-cloud-marker-debug" `
+  -AssetName "StS2Launcher-v0.2.335-mod-selector-deps-cloud-marker-debug-arm64-v8a.apk" `
   -Abi arm64-v8a
 
 .\scripts\install-android-release.ps1 `
-  -ReleaseTag "v0.2.184-loading-scale" `
-  -AssetName "StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk" `
+  -ReleaseTag "v0.2.335-mod-selector-deps-cloud-marker-debug" `
+  -AssetName "StS2Launcher-v0.2.335-mod-selector-deps-cloud-marker-debug-arm64-v8a.apk" `
   -ClearAppData `
   -Launch `
   -CaptureDiagnostics
@@ -229,10 +264,12 @@ Current published APK release:
 Release details:
 
 ```text
-Release: v0.2.184-loading-scale
-Asset: StS2Launcher-v0.2.184-loading-scale-arm64-v8a.apk
-Package: com.sts2launcher.overhaul.fork.dev
-SHA-256: 299f77e9c307b64521ffef73afb890fb2c69bb7a920bf7d24c971cf0b6663f2d
+Release: v0.2.335-mod-selector-deps-cloud-marker-debug
+Asset: StS2Launcher-v0.2.335-mod-selector-deps-cloud-marker-debug-arm64-v8a.apk
+Package: com.sts2launcher.overhaul.fork.local
+VersionName: 0.2.335-mod-selector-deps-cloud-marker-debug
+VersionCode: 335000
+SHA-256: 46799153565feb414a702d590e15cc29bea2cfb5437eb4a11fa5606587db2ac1
 ```
 
 The verifier downloads the GitHub release asset, checks its release SHA-256 digest, confirms the expected native libraries are present, and checks that `libgodot_android.so` contains the Android app-data .NET assembly lookup marker rather than the stale PCK lookup marker.
@@ -245,7 +282,7 @@ Safe public trial checklist:
 4. Download the game through the launcher.
 5. Use Pull from Cloud before Push to Cloud.
 6. Confirm Android local saves/profiles exist before using Push to Cloud.
-7. Treat Push to Cloud as destructive: it makes Steam Cloud reflect Android local saves and can overwrite remote save state.
+7. Treat Push to Cloud as destructive: it makes Steam Cloud reflect Android local saves, can overwrite remote save state, now requires an `ARE YOU SURE?` arming tap, and still requires the final confirmation dialog.
 
 Support boundaries for public testers:
 
@@ -275,7 +312,7 @@ Known current runtime limitations:
 
 - The app now has a validated working ARM64 path through download, cloud pull, cloud push hardening, and game launch, but this is not yet a finished release-candidate pass.
 - Push to Cloud is locally validated after the managed SHA-1 hardening fix, and that fix is included in the verified public APK line. Repeat Push confirmation/cancel smoke on the newest public APK is still required before release-candidate signoff.
-- The public release package has passed update-compatible release builds through `v0.2.184-loading-scale`; repeated local `.local` in-place upgrade coverage remains secondary because local builds use a separate package identity.
+- The public release package has passed update-compatible release builds through `v0.2.187-beta-art-fallback`; the newest APK also has ARM64 visual validation for the responsive launcher download-progress and ready states plus Push confirmation/cancel path. Repeated local `.local` in-place upgrade coverage remains secondary because local builds use a separate package identity.
 - Stale assembly cache behavior still needs repeated local upgrade coverage after signing continuity is fixed.
 - `x86_64` emulator validation is fallback/diagnostic coverage only unless explicitly forcing Godot for crash investigation.
 
@@ -378,4 +415,3 @@ This enables the fast multiplayer mode that the mobile client expects.
 This project is licensed under the [MIT License](LICENSE). See [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md) for third-party dependency licenses.
 
 FMOD requires a commercial license if your project generates revenue. Spine Runtimes require a valid Spine Editor license. See the third-party licenses file for details.
-

--- a/docs/release-notes/v0.2.335-mod-selector-deps-cloud-marker-debug.md
+++ b/docs/release-notes/v0.2.335-mod-selector-deps-cloud-marker-debug.md
@@ -1,0 +1,79 @@
+# StS2 Mobile v0.2.335 - Mod Selector Preview
+
+This prerelease is for Android players and testers who want to try the current mod-selector path and help validate Steam Cloud, branch switching, and save compatibility.
+
+## Download
+
+Use the ARM64 APK:
+
+`StS2Launcher-v0.2.335-mod-selector-deps-cloud-marker-debug-arm64-v8a.apk`
+
+SHA-256:
+
+`46799153565feb414a702d590e15cc29bea2cfb5437eb4a11fa5606587db2ac1`
+
+Package:
+
+`com.sts2launcher.overhaul.fork.local`
+
+This is a local debug/test-channel prerelease, not final release-candidate signoff.
+
+## What Changed
+
+- Adds a first-class Mods section on the main launcher play screen.
+- Adds launcher-owned Android mod selection state.
+- Adds separate vanilla and modded launch behavior.
+- Loads zero Android mods in vanilla mode.
+- Loads selected enabled mods in modded mode.
+- Handles dependency propagation and launch order for selected mods.
+- Keeps Steam Cloud Push locked for active modded-save risk states.
+- Adds selector evidence capture and review scripts.
+
+## Current Validation
+
+Validated on a physical ARM64 Android device:
+
+- Vanilla launch: `playMode=vanilla`, zero scanned mod roots, zero enabled mods.
+- Modded launch: `BaseLib`, `Quick Restart 2`, and `Vanilla and Modded Saves Merger` selected and loaded.
+- Disabled SavesMerger route: SavesMerger disabled/skipped, game reached main menu with two loaded mods.
+- No NativeFallback route or fatal crash signatures in focused logs.
+- Steam Cloud Push was not run in any validation scenario.
+
+Evidence bundle:
+
+`artifacts/android/mod-selector-device-final2-20260625-201238`
+
+## Mod Support Status
+
+Mod support is experimental but now real enough for targeted testing.
+
+Workshop discovery can find subscribed items, and supported staged mods can load through the Android runtime mod-loader path. Some Workshop items are still exposed by Steam only as legacy UGC handles without a direct Android-usable content source. Those items may need manual import.
+
+The highest-priority mod to test is `Vanilla and Modded Saves Merger`, because save continuity is likely to decide whether modded Android play is useful for most players.
+
+## Steam Cloud Safety
+
+- Pull from Steam Cloud is the safer first action.
+- Push to Steam Cloud is never automatic.
+- Manual Push remains guarded because it can overwrite Steam Cloud saves.
+- Push is locked while active modded-save risk states are present.
+
+## Known Issues
+
+- Workshop/mod UX is still being polished.
+- Some subscribed Workshop items may show as needing manual import.
+- SavesMerger needs broader real-save compatibility reports.
+- Samsung/One UI layout and login behavior still need current-version tester reports.
+- Startup/loading speed and diagnostics are active hardening targets.
+
+## Useful Test Reports
+
+Please use the focused GitHub issue templates for:
+
+- crash or startup failures,
+- Steam login or Steam Cloud problems,
+- game download or branch switching problems,
+- mod loading and save-merger behavior,
+- device compatibility results.
+
+Do not publish Steam credentials, Steam Guard codes, tokens, or unsanitized logs.

--- a/docs/testing-needed.md
+++ b/docs/testing-needed.md
@@ -1,0 +1,105 @@
+# Testing Needed
+
+This project needs focused Android tester reports more than broad "works for me" comments. Good reports help confirm device compatibility, Steam Cloud safety, public/beta branch behavior, and mod loading without exposing Steam account data.
+
+## Current Priority
+
+1. **Startup and loading speed**
+   - Time from tapping the app icon to launcher visible.
+   - Time from pressing Start Game to game main menu.
+   - Any black screen, native fallback screen, or app crash.
+
+2. **Public/default game launch**
+   - Fresh install or update install.
+   - Steam login, game download/update, Pull from Cloud, launch.
+   - Whether the expected save/profile appears in-game.
+
+3. **Public-beta or core-release branch switching**
+   - Selected branch shown in the launcher.
+   - Whether the branch downloads or is blocked clearly.
+   - Whether the game launches without silently falling back to public/default.
+   - Any mixed public/beta assets, missing UI art, or hard-lock route.
+
+4. **Workshop/mod support**
+   - Whether subscribed mods are discovered.
+   - Whether the launcher stages or marks the mod as needing manual import.
+   - Which mods are selected.
+   - Whether vanilla launch disables mods correctly.
+   - Whether modded launch reaches the game main menu.
+
+5. **Vanilla and Modded Saves Merger**
+   - This is the highest-priority mod compatibility test.
+   - Report whether existing vanilla saves become usable when the mod is enabled.
+   - Report whether disabling the mod returns to the expected vanilla/modded save behavior.
+
+6. **Samsung/One UI and unusual display sizes**
+   - Launcher layout, keyboard, password manager suggestions, and button reachability.
+   - Include display size/font size settings when reporting UI problems.
+
+## Known Working Evidence So Far
+
+| Device class | Android ABI | Evidence | Status |
+| --- | --- | --- | --- |
+| Physical ARM64 Samsung test device | `arm64-v8a` | Public/default, public-beta runtime matching, Steam Cloud Pull, guarded Push behavior, mod selector, manually imported SavesMerger launch | Working in local validation |
+| Android x86_64 emulator | `x86_64` | Install/routing/native fallback diagnostics only | Not a game-launch proof target |
+
+Add new device results through the device compatibility issue template.
+
+## What To Include In Reports
+
+- APK release tag and APK filename.
+- Device model.
+- Android version and vendor skin version, for example One UI.
+- Clean install or update install.
+- Selected game branch: public/default, public-beta, core-release, or another branch.
+- Whether Steam Cloud Pull was run.
+- Whether Steam Cloud Push was run. If you are not sure, say so.
+- Selected mods and whether launch was vanilla or modded.
+- Screenshot if the problem is visual.
+- Focused logcat if the app crashes or hangs.
+
+## Do Not Share
+
+- Steam password.
+- Steam Guard codes.
+- Steam refresh tokens.
+- Full unsanitized logs containing account names, tokens, or local private paths.
+- Save files publicly unless you intentionally want them visible.
+
+## Quick Logcat Capture
+
+Run this while reproducing a crash or hang:
+
+```powershell
+adb logcat -c
+adb logcat -v time > sts2-mobile-logcat.txt
+```
+
+Stop the command after the issue occurs, then search the file for these terms before attaching the focused section:
+
+```text
+AndroidRuntime
+FATAL EXCEPTION
+Godot
+STS2Mobile
+PatchHelper
+Steam
+SteamKit
+Cloud
+Workshop
+Mods
+NativeFallback
+```
+
+Prefer a small focused excerpt around the failure over a full raw log.
+
+## Best Current Tester Flow
+
+1. Install the latest APK from GitHub Releases.
+2. Open the launcher and record whether it reaches the main launcher screen.
+3. Log in to Steam and download/update the game.
+4. Pull from Steam Cloud before launching with existing saves.
+5. Launch vanilla first.
+6. If vanilla works, test selected mods.
+7. If using SavesMerger, test both enabled and disabled behavior.
+8. File a focused issue using the matching template.


### PR DESCRIPTION
## Summary
- update the default-branch README current status to the latest v0.2.335 prerelease
- add a focused testing-needed guide for Reddit/GitHub visitors
- add crash, Steam/Cloud, branch/download, mods/save-merger, and device compatibility issue templates
- archive the v0.2.335 user-facing release notes in docs/release-notes

## Verification
- checked README has no conflict markers or links to branch-only docs
- verified live v0.2.335 GitHub release title/body was updated separately