### PR TITLE
Bind unsigned candidate provenance

### DIFF
--- a/docs/android-release-validation.md
+++ b/docs/android-release-validation.md
@@ -43,7 +43,7 @@ Current desktop evidence passes 70/70 integrated transfer/automatic-sync/recover
 
 Review 5 must inspect captured Android-local byte hashes and independently read Steam Cloud byte hashes, not UI text. The focused and full logs must show no dropped write or swallowed failure, and every displayed `Synced` result must be tied to the matching verified remote manifest. A persisted baseline is useful evidence, but is not an independent live Steam query by itself.
 
-The Android workflow now builds a candidate artifact only. It does not publish on tags and has no release-promotion job. Its build-info sidecar binds `source_commit`, `candidate_run_id`, `candidate_run_attempt`, `abi`, the exact `apk_sha256`, and the APK's verified actual `signer_sha256`; device evidence must additionally bind the installed base-APK SHA-256, package/version, and device identity. The tested APK must be promoted byte-for-byte after signoff rather than rebuilt. No promotion path should be added until it rejects an incomplete matrix or mismatched evidence binding.
+The Android workflow now builds a candidate artifact only. It does not publish on tags and has no release-promotion job. Its build-info sidecar binds `source_commit`, `candidate_run_id`, `candidate_run_attempt`, `abi`, the workflow-computed `unsigned_apk_sha256`, the exact signed `apk_sha256`, and the APK's verified actual `signer_sha256`; device evidence must additionally bind the installed base-APK SHA-256, package/version, and device identity. The tested APK must be promoted byte-for-byte after signoff rather than rebuilt. No promotion path should be added until it rejects an incomplete matrix or mismatched evidence binding.
 
 The only Stage 5 candidate line is the published v0.2.416 `.local` lineage. The workflow hard-codes package `com.sts2launcher.overhaul.fork.local` and verifies every candidate against the exact v0.2.416 APK bytes and signing certificate before retaining the artifact. This is necessary for an in-place update to preserve and read existing private saves; a side-by-side `.dev` install cannot do that. It is not sufficient release evidence: the dedicated v0.2.416 signing credentials must first be configured, the candidate must pass the complete matrix, and affected-user exports must be verified before any recovery or Steam operation.
 
@@ -117,8 +117,8 @@ Use the existing `cloud_sync_enabled` setting throughout this matrix. Do not add
 4. Confirm the output APK path is present in logs:
    - `android/build/outputs/apk/mono/release/StS2Launcher-v<version>.apk`
 5. Download the candidate artifact and keep it unchanged through the complete Stage 5 matrix.
-6. Confirm its build-info sidecar records the expected `source_commit`, `candidate_run_id`, `candidate_run_attempt`, `abi=arm64-v8a`, actual verified `signer_sha256`, and `apk_sha256`.
-7. Confirm `apk_sha256` matches both the checksum sidecar and a fresh hash of the downloaded APK. Every device capture must bind that hash and the installed base-APK hash.
+6. Confirm its build-info sidecar records the expected `source_commit`, `candidate_run_id`, `candidate_run_attempt`, `abi=arm64-v8a`, actual verified `signer_sha256`, `unsigned_apk_sha256`, and `apk_sha256`.
+7. Copy the lowercase `unsigned_apk_sha256` into the matrix candidate binding; device preflight validates the field but cannot rehash the unavailable unsigned artifact. Confirm `apk_sha256` matches both the checksum sidecar and a fresh hash of the downloaded signed APK. Every device capture must bind that signed hash and the installed base-APK hash.
 
 ## 2) Verify update guardrails
 

--- a/scripts/check-stage5-affected-device.ps1
+++ b/scripts/check-stage5-affected-device.ps1
@@ -322,6 +322,13 @@ if ([int64]$candidateIdentity.versionCode -le $baselineVersionCode) {
 }
 
 $buildInfo = Read-BuildInfo -Path $candidateBuildInfo
+if (-not $buildInfo.ContainsKey('unsigned_apk_sha256')) {
+    throw 'Candidate build-info is missing: unsigned_apk_sha256'
+}
+$unsignedApkSha256 = [string]$buildInfo['unsigned_apk_sha256']
+if ($unsignedApkSha256 -cnotmatch '^[0-9a-f]{64}$') {
+    throw 'Candidate build-info unsigned_apk_sha256 must be a lowercase SHA-256.'
+}
 Assert-BuildInfoValue $buildInfo 'package_name' $requiredPackage
 Assert-BuildInfoValue $buildInfo 'version_name' ([string]$candidateIdentity.versionName)
 Assert-BuildInfoValue $buildInfo 'version_code' ([string]$candidateIdentity.versionCode)
@@ -370,6 +377,7 @@ if ($Mode -eq 'PostInstall') {
     foreach ($binding in @(
         @('packageName', $requiredPackage),
         @('apkSha256', $candidateHash),
+        @('unsignedApkSha256', $unsignedApkSha256),
         @('checksumSha256', (Get-Sha256 -Path $candidateChecksum)),
         @('buildInfoSha256', (Get-Sha256 -Path $candidateBuildInfo)),
         @('sourceCommit', $expectedCommit),
@@ -450,6 +458,7 @@ $manifest = [ordered]@{
     candidate = [ordered]@{
         apkPath = $candidateApk
         apkSha256 = $candidateHash
+        unsignedApkSha256 = $unsignedApkSha256
         checksumPath = $candidateChecksum
         checksumSha256 = Get-Sha256 -Path $candidateChecksum
         buildInfoPath = $candidateBuildInfo

--- a/scripts/new-stage5-physical-matrix-template.ps1
+++ b/scripts/new-stage5-physical-matrix-template.ps1
@@ -313,6 +313,7 @@ $template = [ordered]@{
         candidate = [ordered]@{
             apkPath = '<path-to-unchanged-candidate-apk>'
             apkSha256 = '<sha256>'
+            unsignedApkSha256 = '<sha256-from-candidate-build-info>'
             buildInfoPath = '<path-to-candidate-build-info.txt>'
             buildInfoSha256 = '<sha256>'
             sourceCommit = '<40-character-clean-source-commit>'

--- a/scripts/review-stage5-physical-matrix.ps1
+++ b/scripts/review-stage5-physical-matrix.ps1
@@ -684,6 +684,7 @@ $binding = $matrix.binding
 $candidate = $binding.candidate
 Assert-True -Condition ([string]$candidate.sourceCommit -match '^[0-9a-f]{40}$') -Message 'Matrix candidate sourceCommit must be a lowercase 40-character commit.'
 Assert-True -Condition ([string]$candidate.apkSha256 -match '^[0-9a-f]{64}$') -Message 'Matrix candidate APK hash must be lowercase SHA-256.'
+Assert-True -Condition ([string]$candidate.unsignedApkSha256 -cmatch '^[0-9a-f]{64}$') -Message 'Matrix candidate unsigned APK hash must be lowercase SHA-256.'
 Assert-True -Condition ([string]$candidate.buildInfoSha256 -match '^[0-9a-f]{64}$') -Message 'Matrix candidate build-info hash must be lowercase SHA-256.'
 Assert-True -Condition ([string]$candidate.signerSha256 -match '^[0-9a-f]{64}$') -Message 'Matrix candidate signer hash must be lowercase SHA-256.'
 Assert-True -Condition ([string]$candidate.updateBaselineApkSha256 -match '^[0-9a-f]{64}$') -Message 'Matrix update-baseline APK hash must be lowercase SHA-256.'
@@ -739,6 +740,7 @@ $expectedBuildInfo = [ordered]@{
     source_commit = [string]$candidate.sourceCommit
     candidate_run_id = [string]$candidate.candidateRunId
     candidate_run_attempt = [string]$candidate.candidateRunAttempt
+    unsigned_apk_sha256 = [string]$candidate.unsignedApkSha256
     apk_sha256 = ([string]$candidate.apkSha256).ToLowerInvariant()
     update_baseline_tag = [string]$candidate.updateBaselineTag
     update_baseline_asset_name = [string]$candidate.updateBaselineAssetName
@@ -2208,6 +2210,7 @@ $report = [ordered]@{
     sourceMatrixSha256 = $matrixSha256
     sourceCommit = [string]$candidate.sourceCommit
     candidateApkSha256 = [string]$candidate.apkSha256
+    candidateUnsignedApkSha256 = [string]$candidate.unsignedApkSha256
     candidateBuildInfoSha256 = [string]$candidate.buildInfoSha256
     packageName = [string]$candidate.packageName
     versionName = [string]$candidate.versionName

--- a/scripts/test-stage5-affected-device-preflight.ps1
+++ b/scripts/test-stage5-affected-device-preflight.ps1
@@ -23,6 +23,7 @@ $fakeApkTool = Join-Path $testRoot $(if ($runningOnWindows) { 'fake-apk-tool.exe
 $adbLog = Join-Path $testRoot 'adb-invocations.txt'
 $packageName = 'com.sts2launcher.overhaul.fork.local'
 $baselineHash = 'fdf2dcfcf2352d0e1a370da76922fb5b70cee3654d98c5fe9afbbd39554fc17b'
+$unsignedApkSha256 = '60f3f748f358e009ba6fc5baf615cec23f5cfcc9ec545f41c0cf71419d5bed15'
 $signer = 'FD0E3D5ACF435C1D23BFC5C426E99AA9EB5808619FF1FC214FFCA99CFAC7E57A'
 $sourceCommit = (& git -C (Resolve-Path (Join-Path $PSScriptRoot '..')).Path rev-parse HEAD).Trim().ToLowerInvariant()
 if ($LASTEXITCODE -ne 0 -or $sourceCommit -notmatch '^[0-9a-f]{40}$') { throw 'Could not resolve fixture source commit.' }
@@ -306,6 +307,7 @@ exit 64
             "source_commit=$sourceCommit",
             'candidate_run_id=123456789',
             'candidate_run_attempt=1',
+            "unsigned_apk_sha256=$unsignedApkSha256",
             "apk_sha256=$hash",
             'update_baseline_tag=v0.2.416-startup-recovery-ime',
             'update_baseline_asset_name=StS2Launcher-v0.2.416-startup-recovery-ime-local-arm64-v8a.apk',
@@ -386,6 +388,7 @@ exit 64
     $pre = [IO.File]::ReadAllText($preManifest) | ConvertFrom-Json
     Assert-True ([string]$pre.mode -eq 'PreInstall' -and [string]$pre.result -eq 'verified') 'PreInstall manifest is not verified.'
     Assert-True ([string]$pre.device.pulledApkSha256 -eq $baselineHash) 'PreInstall did not bind the pinned baseline bytes.'
+    Assert-True ([string]$pre.candidate.unsignedApkSha256 -ceq $unsignedApkSha256) 'PreInstall did not bind the unsigned candidate bytes recorded by the build.'
 
     [Environment]::SetEnvironmentVariable('STS2_PREFLIGHT_FAKE_INSTALLED_APK', $valid.Apk, [EnvironmentVariableTarget]::Process)
     $postDirectory = Invoke-Preflight -Mode PostInstall -Candidate $valid -OutputName post-success -PriorManifest $preManifest
@@ -428,6 +431,31 @@ exit 64
     [IO.File]::AppendAllText($wrongHash.Apk, 'tampered', [Text.UTF8Encoding]::new($false))
     Assert-PreflightRejects -Label 'wrong candidate hash binding' -Pattern 'checksum mismatch' -Action {
         Invoke-Preflight -Mode PreInstall -Candidate $wrongHash -OutputName reject-hash | Out-Null
+    }
+
+    $missingUnsignedHash = New-CandidateFixture -Name missing-unsigned-hash
+    [IO.File]::WriteAllLines(
+        $missingUnsignedHash.BuildInfo,
+        @([IO.File]::ReadAllLines($missingUnsignedHash.BuildInfo) | Where-Object {
+            -not $_.StartsWith('unsigned_apk_sha256=', [StringComparison]::Ordinal)
+        }),
+        [Text.UTF8Encoding]::new($false)
+    )
+    Assert-PreflightRejects -Label 'missing unsigned candidate hash' -Pattern 'missing: unsigned_apk_sha256' -Action {
+        Invoke-Preflight -Mode PreInstall -Candidate $missingUnsignedHash -OutputName reject-missing-unsigned-hash | Out-Null
+    }
+
+    $malformedUnsignedHash = New-CandidateFixture -Name malformed-unsigned-hash
+    [IO.File]::WriteAllText(
+        $malformedUnsignedHash.BuildInfo,
+        ([IO.File]::ReadAllText($malformedUnsignedHash.BuildInfo)).Replace(
+            "unsigned_apk_sha256=$unsignedApkSha256",
+            "unsigned_apk_sha256=$('A' * 64)"
+        ),
+        [Text.UTF8Encoding]::new($false)
+    )
+    Assert-PreflightRejects -Label 'malformed unsigned candidate hash' -Pattern 'must be a lowercase SHA-256' -Action {
+        Invoke-Preflight -Mode PreInstall -Candidate $malformedUnsignedHash -OutputName reject-malformed-unsigned-hash | Out-Null
     }
 
     [Environment]::SetEnvironmentVariable('STS2_PREFLIGHT_FAKE_DEVICE_MODE', 'multiple', [EnvironmentVariableTarget]::Process)
@@ -479,7 +507,7 @@ exit 64
         Assert-True (@($allowedAdb | Where-Object { $invocation -match $_ }).Count -eq 1) "Unexpected ADB operation observed: $invocation"
     }
 
-    Write-Host 'Stage 5 affected-device preflight tests passed: pre/post exact identity, fail-closed version/signer/process/continuity, and no mutating ADB operations.'
+    Write-Host 'Stage 5 affected-device preflight tests passed: pre/post exact identity, unsigned-candidate binding, fail-closed version/signer/process/continuity, and no mutating ADB operations.'
 } finally {
     foreach ($name in $environmentNames) {
         [Environment]::SetEnvironmentVariable($name, $oldEnvironment[$name], [EnvironmentVariableTarget]::Process)

--- a/scripts/test-stage5-physical-matrix-reviewer.ps1
+++ b/scripts/test-stage5-physical-matrix-reviewer.ps1
@@ -13,6 +13,7 @@ $sourceCommit = '1234567890abcdef1234567890abcdef12345678'
 $steamId64 = '76561198000000001'
 $packageName = 'com.sts2launcher.overhaul.fork.local'
 $signerSha256 = 'fd0e3d5acf435c1d23bfc5c426e99aa9eb5808619ff1fc214ffca99cfac7e57a'
+$unsignedApkSha256 = '60f3f748f358e009ba6fc5baf615cec23f5cfcc9ec545f41c0cf71419d5bed15'
 $deviceSerial = 'fixture-device-01'
 $contexts = [ordered]@{
     'vanilla-public' = [ordered]@{
@@ -884,6 +885,7 @@ try {
         "source_commit=$sourceCommit",
         'candidate_run_id=123456789',
         'candidate_run_attempt=1',
+        "unsigned_apk_sha256=$unsignedApkSha256",
         "apk_sha256=$candidateHash",
         'update_baseline_tag=v0.2.416-startup-recovery-ime',
         'update_baseline_asset_name=StS2Launcher-v0.2.416-startup-recovery-ime-local-arm64-v8a.apk',
@@ -967,6 +969,7 @@ try {
     $matrix = Get-Content -LiteralPath $templatePath -Raw | ConvertFrom-Json
     $matrix.binding.candidate.apkPath = $candidatePath
     $matrix.binding.candidate.apkSha256 = $candidateHash
+    $matrix.binding.candidate.unsignedApkSha256 = $unsignedApkSha256
     $matrix.binding.candidate.buildInfoPath = $buildInfoPath
     $matrix.binding.candidate.buildInfoSha256 = Get-FileHashHex -Path $buildInfoPath
     $matrix.binding.candidate.sourceCommit = $sourceCommit
@@ -1081,6 +1084,7 @@ try {
     if ($review.result -ne 'passed' -or
         $review.rowsPassed -ne 10 -or
         $review.semanticChecksPassed -ne 11 -or
+        [string]$review.candidateUnsignedApkSha256 -cne $unsignedApkSha256 -or
         [int]$review.androidExportsBoundToRawCollector -ne $androidMapping.Count) {
         throw 'Valid nondebuggable Stage 5 fixture did not produce a complete pass report.'
     }
@@ -1147,6 +1151,40 @@ try {
             -BuildInfoValue $lineageCase.BuildInfoValue `
             -Label $lineageCase.Label
     }
+
+    $uppercaseUnsignedMatrix = Get-Content -LiteralPath $validMatrixPath -Raw | ConvertFrom-Json
+    $uppercaseUnsignedMatrix.binding.candidate.unsignedApkSha256 = $unsignedApkSha256.ToUpperInvariant()
+    $uppercaseUnsignedPath = Join-Path $testRoot 'uppercase-unsigned-apk-sha256.json'
+    Write-JsonNoBom -Path $uppercaseUnsignedPath -Value $uppercaseUnsignedMatrix
+    Assert-ReviewerRejects `
+        -MatrixPath $uppercaseUnsignedPath `
+        -Label 'Uppercase unsigned candidate hash binding' `
+        -Aapt $aaptPath `
+        -ApkSigner $apkSignerPath `
+        -ExpectedErrorPattern 'unsigned APK hash must be lowercase SHA-256'
+
+    $mismatchedUnsignedMatrix = Get-Content -LiteralPath $validMatrixPath -Raw | ConvertFrom-Json
+    $mismatchedUnsignedDirectory = Join-Path $testRoot 'negative/mismatched-unsigned-apk-sha256'
+    New-Item -ItemType Directory -Force -Path $mismatchedUnsignedDirectory | Out-Null
+    $mismatchedUnsignedBuildInfoPath = Join-Path $mismatchedUnsignedDirectory 'candidate.build-info.txt'
+    [IO.File]::WriteAllText(
+        $mismatchedUnsignedBuildInfoPath,
+        ([IO.File]::ReadAllText($buildInfoPath)).Replace(
+            "unsigned_apk_sha256=$unsignedApkSha256",
+            "unsigned_apk_sha256=$('0' * 64)"
+        ),
+        [Text.UTF8Encoding]::new($false)
+    )
+    $mismatchedUnsignedMatrix.binding.candidate.buildInfoPath = $mismatchedUnsignedBuildInfoPath
+    $mismatchedUnsignedMatrix.binding.candidate.buildInfoSha256 = Get-FileHashHex -Path $mismatchedUnsignedBuildInfoPath
+    $mismatchedUnsignedPath = Join-Path $testRoot 'mismatched-unsigned-apk-sha256.json'
+    Write-JsonNoBom -Path $mismatchedUnsignedPath -Value $mismatchedUnsignedMatrix
+    Assert-ReviewerRejects `
+        -MatrixPath $mismatchedUnsignedPath `
+        -Label 'Build-info unsigned candidate hash mismatch' `
+        -Aapt $aaptPath `
+        -ApkSigner $apkSignerPath `
+        -ExpectedErrorPattern 'build-info unsigned_apk_sha256 mismatch'
 
     $missingMatrix = Get-Content -LiteralPath $validMatrixPath -Raw | ConvertFrom-Json
     $row9 = @($missingMatrix.rows | Where-Object { [int]$_.row -eq 9 })[0]
@@ -1416,7 +1454,7 @@ try {
         -ApkSigner $apkSignerPath `
         -ExpectedErrorPattern 'indexed captured SHA-256.*mismatch'
 
-    Write-Host 'Stage 5 physical matrix reviewer tests passed: 24/24'
+    Write-Host 'Stage 5 physical matrix reviewer tests passed: 26/26'
 } finally {
     $resolvedTestRoot = [IO.Path]::GetFullPath($testRoot)
     $tempPrefix = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd(


### PR DESCRIPTION
## Summary
- bind the workflow-computed unsigned APK SHA-256 into the physical matrix
- require exact build-info equality and Pre/Post device continuity
- add malformed/missing/mismatch regression coverage

## Validation
- affected-device preflight suite passes
- physical matrix reviewer passes 26/26
- diff check passes

No APK, device state, or Steam state is changed.