### PR TITLE
Align Steam cloud job timeout

### DIFF
--- a/scripts/audit-steam-version-selection.cloud-safety.push-requests.execution.ps1
+++ b/scripts/audit-steam-version-selection.cloud-safety.push-requests.execution.ps1
@@ -615,6 +615,7 @@ function Add-SteamVersionSelectionCloudSafetyPushExecutionChecks {
         @(
             "EnsureConnected\(cancellationToken\)",
             "_sendLock\.WaitAsync\(cancellationToken\)",
+            "job\.Timeout = TimeSpan\.FromMilliseconds\(CloudRpcTimeoutMs\)",
             "WaitForCloudJobAsync",
             "cancellationToken\.ThrowIfCancellationRequested\(\)",
             "Task\.Delay\(",

--- a/src/STS2Mobile/Steam/SteamConnection.CloudMessages.cs
+++ b/src/STS2Mobile/Steam/SteamConnection.CloudMessages.cs
@@ -30,6 +30,7 @@ internal sealed partial class SteamConnection
                 CloudRpcEndpoint(method),
                 request
             );
+            job.Timeout = TimeSpan.FromMilliseconds(CloudRpcTimeoutMs);
             var response = await WaitForCloudJobAsync(
                 method,
                 job.ToTask(),


### PR DESCRIPTION
## What changed
- align SteamKit's internal CCloud job timeout with the launcher's 45-second cloud RPC timeout
- lock the timeout assignment into the existing cloud-safety audit

## Root cause
SteamKit2 3.4.0 cancels async jobs after 10 seconds by default. The real Android device connected to Steam, but cloud enumeration legitimately exceeded that hidden deadline and was canceled before the launcher's own timeout could apply.

## Impact
All CCloud operations through the single SendCloud path—enumeration, upload, download, commit, and delete—now use the intended timeout. Play still fails closed if Steam does not answer.

## Validation
- real device reproduced the exact 10-second cancellation without any save overwrite
- cloud production-path probe: 70/70
- hard process-death probe: 118/118
- Steam version-selection static audit: 984 checks
- Release build: 0 warnings, 0 errors